### PR TITLE
test: 修改react-native-error-boundary测试demo

### DIFF
--- a/react-native-error-boundary/ErrorBoundaryTest.tsx
+++ b/react-native-error-boundary/ErrorBoundaryTest.tsx
@@ -1,7 +1,6 @@
 import React, { PropsWithChildren, useState } from 'react';
-import { View, Alert, Text, StyleSheet } from 'react-native';
-import { TestSuite, Tester } from '@rnoh/testerino';
-import { Button, TestCase } from '../../components';
+import { View, Alert, Text, Button, StyleSheet } from 'react-native';
+import { TestSuite, Tester, TestCase } from '@rnoh/testerino';
 import ErrorBoundary from 'react-native-error-boundary';
 
 export const ErrorBoundaryTest = () => {
@@ -12,43 +11,43 @@ export const ErrorBoundaryTest = () => {
     return (
         <Tester>
             <TestSuite name="ErrorBoundaryDefaultTest">
-                <TestCase.Example itShould="Catch the exception, show a default error page">
+                <TestCase itShould="Catch the exception, show a default error page">
                     <ErrorBoundary>
                         <Button
-                            label="Click the button, Trigger a Exception"
+                            title="Click the button, Trigger a Exception"
                             onPress={() => {
                                 setShouldThrow(true);
                             }}
                         />
                         {shouldThrow && (<MaybeThrows>Content</MaybeThrows>)}
                     </ErrorBoundary>
-                </TestCase.Example>
+                </TestCase>
             </TestSuite>
             <TestSuite name="ErrorBoundaryHandleTest" >
-                <TestCase.Example itShould="Catch the exception, show a default error page and a pop-up window that displays abnormal content defined by the onError api">
+                <TestCase itShould="Catch the exception, show a default error page and a pop-up window that displays abnormal content defined by the onError api">
                     <ErrorBoundary onError={errorHandler}>
                         <Button
-                            label="Click the button, Trigger a Exception"
+                            title="Click the button, Trigger a Exception"
                             onPress={() => {
                                 setShowErrorApi(true);
                             }}
                         />
                         {showErrorApi && (<MaybeThrows>Content</MaybeThrows>)}
                     </ErrorBoundary>
-                </TestCase.Example>
+                </TestCase>
             </TestSuite>
             <TestSuite name="ErrorBoundaryFallbackTest" >
-                <TestCase.Example itShould="Catch the exception, show customized error page defined by the FallbackComponent api">
+                <TestCase itShould="Catch the exception, show customized error page defined by the FallbackComponent api">
                     <ErrorBoundary FallbackComponent={CustomFallback}>
                         <Button
-                            label="Click the button, Trigger a Exception"
+                            title="Click the button, Trigger a Exception"
                             onPress={() => {
                                 setShowFallback(true);
                             }}
                         />
                         {showFallback && (<MaybeThrows>Content</MaybeThrows>)}
                     </ErrorBoundary>
-                </TestCase.Example>
+                </TestCase>
             </TestSuite>
         </Tester>
     );
@@ -66,7 +65,7 @@ const CustomFallback = (props: { error: Error, resetError: Function }) => (
         <Text style={styles.errorContent}>{props.error.toString()}</Text>
         <View style={styles.fallbackButtonParent}>
             <View style={styles.fallbackButton}>
-                <Button onPress={() => props.resetError} label={'Try again'} />
+                <Button onPress={() => props.resetError} title={'Try again'} />
             </View>
         </View>
     </View>


### PR DESCRIPTION
# Summary
修改react-native-error-boundary测试demo：将Button、TestCase组件修改为testerino库中的
close #362

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)