### PR TITLE
test:修改react-native-device-info 的测试demo

### DIFF
--- a/react-native-device-info/RNDeviceInfoDemo.tsx
+++ b/react-native-device-info/RNDeviceInfoDemo.tsx
@@ -67,7 +67,6 @@ export default class App extends Component {
      deviceJSON.readableVersion = DeviceInfo.getReadableVersion();
      deviceJSON.buildNumber = DeviceInfo.getBuildNumber();
      deviceJSON.isTablet = DeviceInfo.isTablet();
-     deviceJSON.isLowRamDevice = DeviceInfo.isLowRamDevice()
      deviceJSON.appName = DeviceInfo.getApplicationName();
      deviceJSON.brand = DeviceInfo.getBrand();
      deviceJSON.model = DeviceInfo.getModel();
@@ -133,6 +132,7 @@ export default class App extends Component {
     let deviceJSON = {};
 
     try {
+      deviceJSON.isLowRamDevice = await DeviceInfo.isLowRamDevice()
       deviceJSON.manufacturer = await DeviceInfo.getManufacturer();
       deviceJSON.powerStatus = await DeviceInfo.getPowerState();                                  
       deviceJSON.buildId = await DeviceInfo.getBuildId();

--- a/react-native-device-info/test/RNDeviceInfoTest.tsx
+++ b/react-native-device-info/test/RNDeviceInfoTest.tsx
@@ -1,12 +1,19 @@
-import { TestSuite } from '@rnoh/testerino';
-import { TestCase } from '../components';
-import * as React from 'react';
-import DeviceInfo from 'react-native-device-info';
+import { TestSuite,TestCase,Tester } from '@rnoh/testerino';
+import React from 'react';
+import DeviceInfo from '@react-native-oh-tpl/react-native-device-info/src/RNDeviceInfo';
+import {
+  SafeAreaView,
+  ScrollView,
+  View,
+  Text,
+  StatusBar
+} from "react-native";
 
-export function DeviceInfoTest() {
+const RNDeviceInfoTest = () =>  {
     return (
-        <TestSuite name="DeviceInfo">
-            <TestCase.Logical
+    <Tester style={{ flex: 1, marginTop: 30 }}>
+    <ScrollView>
+            <TestCase
                 itShould="DeviceInfo.getApiLevel"
                 fn={({ expect }: any) => {
                     DeviceInfo.getApiLevel().then((result) => {
@@ -16,19 +23,35 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getApiLevelSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getApiLevelSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getApplicationName"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getApplicationName()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.getAvailableLocationProviders"
+                fn={({ expect }: any) => {
+                    DeviceInfo.getAvailableLocationProviders().then((result) => {
+                        expect(result).to.be.a('object');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.getAvailableLocationProvidersSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.getAvailableLocationProvidersSync()).to.be.a('object');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.getBaseOs"
                 fn={({ expect }: any) => {
                     DeviceInfo.getBaseOs().then((result) => {
@@ -38,13 +61,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBaseOsSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBaseOsSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBatteryLevel"
                 fn={({ expect }: any) => {
                     DeviceInfo.getBatteryLevel().then((result) => {
@@ -54,13 +77,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBatteryLevelSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBatteryLevelSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBootloader"
                 fn={({ expect }: any) => {
                     DeviceInfo.getBootloader().then((result) => {
@@ -70,13 +93,19 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBootloaderSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBootloaderSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.getBrand"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.getBrand()).to.be.a('string');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.getBuildId"
                 fn={({ expect }: any) => {
                     DeviceInfo.getBuildId().then((result) => {
@@ -86,31 +115,25 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
-                itShould="DeviceInfo.getBrand"
-                fn={({ expect }: any) => {
-                    expect(DeviceInfo.getBrand()).to.be.a('string');
-                }}
-            />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBuildIdSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBuildIdSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBuildNumber"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBuildNumber()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getBundleId"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getBundleId()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getCarrier"
                 fn={({ expect }: any) => {
                     DeviceInfo.getCarrier().then((result) => {
@@ -120,13 +143,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getCarrierSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getCarrierSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getCodename"
                 fn={({ expect }: any) => {
                     DeviceInfo.getCodename().then((result) => {
@@ -136,13 +159,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getCodenameSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getCodenameSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDevice"
                 fn={({ expect }: any) => {
                     DeviceInfo.getDevice().then((result) => {
@@ -152,19 +175,19 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDeviceSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getDeviceSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDeviceId"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getDeviceId()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDeviceName"
                 fn={({ expect }: any) => {
                     DeviceInfo.getDeviceName().then((result) => {
@@ -174,19 +197,19 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDeviceNameSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getDeviceNameSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDeviceType"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getDeviceType()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDisplay"
                 fn={({ expect }: any) => {
                     DeviceInfo.getDisplay().then((result) => {
@@ -196,13 +219,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getDisplaySync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getDisplaySync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFingerprint"
                 fn={({ expect }: any) => {
                     DeviceInfo.getFingerprint().then((result) => {
@@ -212,13 +235,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFingerprintSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getFingerprintSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFirstInstallTime"
                 fn={({ expect }: any) => {
                     DeviceInfo.getFirstInstallTime().then((result) => {
@@ -228,13 +251,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFirstInstallTimeSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getFirstInstallTimeSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFontScale"
                 fn={({ expect }: any) => {
                     DeviceInfo.getFontScale().then((result) => {
@@ -244,13 +267,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFontScaleSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getFontScaleSync()).to.not.be.undefined;
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFreeDiskStorage"
                 fn={({ expect }: any) => {
                     DeviceInfo.getFreeDiskStorage().then((result) => {
@@ -260,7 +283,7 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFreeDiskStorageOld"
                 fn={({ expect }: any) => {
                     DeviceInfo.getFreeDiskStorageOld().then((result) => {
@@ -270,19 +293,19 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFreeDiskStorageSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getFreeDiskStorageSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getFreeDiskStorageOldSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getFreeDiskStorageOldSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getHardware"
                 fn={({ expect }: any) => {
                     DeviceInfo.getHardware().then((result) => {
@@ -292,13 +315,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getHardwareSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getHardwareSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getHost"
                 fn={({ expect }: any) => {
                     DeviceInfo.getHost().then((result) => {
@@ -308,13 +331,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getHostSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getHostSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getIncremental"
                 fn={({ expect }: any) => {
                     DeviceInfo.getIncremental().then((result) => {
@@ -324,13 +347,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getIncrementalSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getIncrementalSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getInstallerPackageName"
                 fn={({ expect }: any) => {
                     DeviceInfo.getInstallerPackageName().then((result) => {
@@ -340,13 +363,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getInstallerPackageNameSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getInstallerPackageNameSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getInstanceId"
                 fn={({ expect }: any) => {
                     DeviceInfo.getInstanceId().then((result) => {
@@ -356,13 +379,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getInstanceIdSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getInstanceIdSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getIpAddress"
                 fn={({ expect }: any) => {
                     DeviceInfo.getIpAddress().then((result) => {
@@ -372,13 +395,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getIpAddressSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getIpAddressSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getLastUpdateTime"
                 fn={({ expect }: any) => {
                     DeviceInfo.getLastUpdateTime().then((result) => {
@@ -388,13 +411,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getLastUpdateTimeSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getLastUpdateTimeSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getManufacturer"
                 fn={({ expect }: any) => {
                     DeviceInfo.getManufacturer().then((result) => {
@@ -404,25 +427,41 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getManufacturerSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getManufacturerSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.getPowerState"
+                fn={({ expect }: any) => {
+                    DeviceInfo.getPowerState().then((result) => {
+                        expect(result).to.be.a('object');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.getPowerStateSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.getPowerStateSync()).to.be.a('object');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.getModel"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getModel()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getReadableVersion"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getReadableVersion()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getProduct"
                 fn={({ expect }: any) => {
                     DeviceInfo.getProduct().then((result) => {
@@ -432,7 +471,7 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSecurityPatch"
                 fn={({ expect }: any) => {
                     DeviceInfo.getSecurityPatch().then((result) => {
@@ -442,13 +481,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSecurityPatchSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getSecurityPatchSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSerialNumber"
                 fn={({ expect }: any) => {
                     DeviceInfo.getSerialNumber().then((result) => {
@@ -458,41 +497,25 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSerialNumberSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getSerialNumberSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSystemName"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getSystemName()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSystemVersion"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getSystemVersion()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
-                itShould="DeviceInfo.getTags"
-                fn={({ expect }: any) => {
-                    DeviceInfo.getTags().then((result) => {
-                        expect(result).to.be.a('string');
-                    }).catch((error) => {
-                        expect(error).to.not.be.undefined;
-                    })
-                }}
-            />
-            <TestCase.Logical
-                itShould="DeviceInfo.getTagsSync"
-                fn={({ expect }: any) => {
-                    expect(DeviceInfo.getTagsSync()).to.be.a('string');
-                }}
-            />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getTotalDiskCapacity"
                 fn={({ expect }: any) => {
                     DeviceInfo.getTotalDiskCapacity().then((result) => {
@@ -502,7 +525,7 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getTotalDiskCapacityOld"
                 fn={({ expect }: any) => {
                     DeviceInfo.getTotalDiskCapacityOld().then((result) => {
@@ -512,19 +535,55 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getTotalDiskCapacitySync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getTotalDiskCapacitySync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getTotalDiskCapacityOldSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getTotalDiskCapacityOldSync()).to.be.a('number');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.getTotalMemory"
+                fn={({ expect }: any) => {
+                    DeviceInfo.getTotalMemory().then((result) => {
+                        expect(result).to.be.a('number');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.getTotalMemorySync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.getTotalMemorySync()).to.be.a('number');
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.isLowRamDevice"
+                fn={({ expect }: any) => {
+                    DeviceInfo.isLowRamDevice().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.getUsedMemory"
+                fn={({ expect }: any) => {
+                    DeviceInfo.getUsedMemory().then((result) => {
+                        expect(result).to.be.a('number');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.getType"
                 fn={({ expect }: any) => {
                     DeviceInfo.getType().then((result) => {
@@ -534,13 +593,13 @@ export function DeviceInfoTest() {
                     })
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getTypeSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getTypeSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getUniqueId"
                 fn={({ expect }: any) => {
                     DeviceInfo.getUniqueId().then((result) => {
@@ -550,13 +609,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getUniqueIdSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getUniqueIdSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getUserAgent"
                 fn={({ expect }: any) => {
                     DeviceInfo.getUserAgent().then((result) => {
@@ -566,19 +625,19 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getUserAgentSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getUserAgentSync()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getVersion"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getVersion()).to.be.a('string');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.hasGms"
                 fn={({ expect }: any) => {
                     DeviceInfo.hasGms().then((result) => {
@@ -588,13 +647,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.hasGmsSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.hasGmsSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.hasHms"
                 fn={({ expect }: any) => {
                     DeviceInfo.hasHms().then((result) => {
@@ -604,13 +663,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.hasHmsSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.hasHmsSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isAirplaneMode"
                 fn={({ expect }: any) => {
                     DeviceInfo.isAirplaneMode().then((result) => {
@@ -620,13 +679,39 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isAirplaneModeSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isAirplaneModeSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.isKeyboardConnected"
+                fn={({ expect }: any) => {
+                    DeviceInfo.isKeyboardConnected().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.isMouseConnected"
+                fn={({ expect }: any) => {
+                    DeviceInfo.isMouseConnected().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.isMouseConnectedSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.isMouseConnectedSync()).to.be.a('Boolean');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.isBatteryCharging"
                 fn={({ expect }: any) => {
                     DeviceInfo.isBatteryCharging().then((result) => {
@@ -636,13 +721,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isBatteryChargingSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isBatteryChargingSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isCameraPresent"
                 fn={({ expect }: any) => {
                     DeviceInfo.isCameraPresent().then((result) => {
@@ -652,23 +737,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isCameraPresentSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isCameraPresentSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
-                itShould="DeviceInfo.isEmulator"
-                fn={({ expect }: any) => {
-                    DeviceInfo.isEmulator().then((result) => {
-                        expect(result).to.be.a('Boolean');
-                    }).catch((err) => {
-                        expect(err).to.not.be.undefined;
-                    });
-                }}
-            />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isHeadphonesConnected"
                 fn={({ expect }: any) => {
                     DeviceInfo.isHeadphonesConnected().then((result) => {
@@ -678,25 +753,61 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isHeadphonesConnectedSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isHeadphonesConnectedSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isWiredHeadphonesConnected"
                 fn={({ expect }: any) => {
-                    expect(DeviceInfo.isWiredHeadphonesConnected()).to.be.a('Boolean');
+                    DeviceInfo.isWiredHeadphonesConnected().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.isWiredHeadphonesConnectedSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.isWiredHeadphonesConnectedSync()).to.be.a('Boolean');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.isBluetoothHeadphonesConnected"
                 fn={({ expect }: any) => {
-                    expect(DeviceInfo.isBluetoothHeadphonesConnected()).to.be.a('Boolean');
+                    DeviceInfo.isBluetoothHeadphonesConnected().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.isBluetoothHeadphonesConnectedSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.isBluetoothHeadphonesConnectedSync()).to.be.a('Boolean');
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.isLandscape"
+                fn={({ expect }: any) => {
+                    DeviceInfo.isLandscape().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.isLandscapeSync"
+                fn={({ expect }: any) => {
+                    expect(DeviceInfo.isLandscapeSync()).to.be.a('Boolean');
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.isLocationEnabled"
                 fn={({ expect }: any) => {
                     DeviceInfo.isLocationEnabled().then((result) => {
@@ -706,19 +817,29 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.isLocationEnabledSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isLocationEnabledSync()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
+                itShould="DeviceInfo.isPinOrFingerprintSet"
+                fn={({ expect }: any) => {
+                    DeviceInfo.isPinOrFingerprintSet().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
+                }}
+            />
+            <TestCase
                 itShould="DeviceInfo.isTablet"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.isTablet()).to.be.a('Boolean');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supported32BitAbis"
                 fn={({ expect }: any) => {
                     DeviceInfo.supported32BitAbis().then((result) => {
@@ -728,13 +849,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supported32BitAbisSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.supported32BitAbisSync()).to.be.a('Array');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supported64BitAbis"
                 fn={({ expect }: any) => {
                     DeviceInfo.supported64BitAbis().then((result) => {
@@ -744,13 +865,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supported64BitAbisSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.supported64BitAbisSync()).to.be.a('Array');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supportedAbis"
                 fn={({ expect }: any) => {
                     DeviceInfo.supportedAbis().then((result) => {
@@ -760,13 +881,13 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.supportedAbisSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.supportedAbisSync()).to.be.a('Array');
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSupportedMediaTypeList"
                 fn={({ expect }: any) => {
                     DeviceInfo.getSupportedMediaTypeList().then((result) => {
@@ -776,12 +897,14 @@ export function DeviceInfoTest() {
                     });
                 }}
             />
-            <TestCase.Logical
+            <TestCase
                 itShould="DeviceInfo.getSupportedMediaTypeListSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.getSupportedMediaTypeListSync()).to.be.a('Array');
                 }}
             />
-        </TestSuite>
+        </ScrollView>
+        </Tester>
     );
-}
+};
+export default RNDeviceInfoTest


### PR DESCRIPTION
# Summary
- 修改react-native-device-info 的测试demo。
Close : 修改isLowRamDevice 接口返回结果显示不正常的问题 [#469](https://github.com/react-native-oh-library/RNOHDCS/issues/469)。

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
