### PR TITLE
test:修改react-native-device-info 测试demo

### DIFF
--- a/react-native-device-info/RNDeviceInfoDemo.tsx
+++ b/react-native-device-info/RNDeviceInfoDemo.tsx
@@ -120,7 +120,6 @@ export default class App extends Component {
     deviceJSON.supported64BitAbis = DeviceInfo.supported64BitAbisSync();
     deviceJSON.hasGms = DeviceInfo.hasGmsSync();
     deviceJSON.hasHms = DeviceInfo.hasHmsSync();
-    deviceJSON.isKeyboardConnected = DeviceInfo.isKeyboardConnectedSync();
     deviceJSON.isMouseConnected = DeviceInfo.isMouseConnectedSync();
     deviceJSON.isWiredHeadphonesConnected = DeviceInfo.isWiredHeadphonesConnectedSync();
     deviceJSON.isBluetoothHeadphonesConnected = DeviceInfo.isBluetoothHeadphonesConnectedSync();
@@ -132,7 +131,10 @@ export default class App extends Component {
     let deviceJSON = {};
 
     try {
-      deviceJSON.isLowRamDevice = await DeviceInfo.isLowRamDevice()
+      deviceJSON.hasNotch = await DeviceInfo.hasNotch();
+      deviceJSON.macAddress = await DeviceInfo.getMacAddress();
+      deviceJSON.uniqueId = await DeviceInfo.getUniqueId();
+      deviceJSON.isLowRamDevice = await DeviceInfo.isLowRamDevice();
       deviceJSON.manufacturer = await DeviceInfo.getManufacturer();
       deviceJSON.powerStatus = await DeviceInfo.getPowerState();                                  
       deviceJSON.buildId = await DeviceInfo.getBuildId();

--- a/react-native-device-info/test/RNDeviceInfoTest.tsx
+++ b/react-native-device-info/test/RNDeviceInfoTest.tsx
@@ -417,6 +417,16 @@ const RNDeviceInfoTest = () =>  {
                     expect(DeviceInfo.getLastUpdateTimeSync()).to.be.a('number');
                 }}
             />
+             <TestCase
+                itShould="DeviceInfo.getMacAddress"
+                fn={({ expect }: any) => {
+                    DeviceInfo.getMacAddress().then((result) => {
+                        expect(result).to.be.a('string');
+                    }).catch((error) => {
+                        expect(error).to.not.be.undefined;
+                    })
+                }}
+            />
             <TestCase
                 itShould="DeviceInfo.getManufacturer"
                 fn={({ expect }: any) => {
@@ -667,6 +677,16 @@ const RNDeviceInfoTest = () =>  {
                 itShould="DeviceInfo.hasHmsSync"
                 fn={({ expect }: any) => {
                     expect(DeviceInfo.hasHmsSync()).to.be.a('Boolean');
+                }}
+            />
+            <TestCase
+                itShould="DeviceInfo.hasNotch"
+                fn={({ expect }: any) => {
+                    DeviceInfo.hasNotch().then((result) => {
+                        expect(result).to.be.a('Boolean');
+                    }).catch((err) => {
+                        expect(err).to.not.be.undefined;
+                    });
                 }}
             />
             <TestCase


### PR DESCRIPTION
# Summary

*  修改react-native-device-info 测试demo
    Close : 新增hasNotch、getMacAddress、getUniqueId接口测试 [#501](https://github.com/react-native-oh-library/RNOHDCS/issues/501)。

## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码