### PR TITLE
test:新增react-native-screenshot-prevent的demo #612

### DIFF
--- a/react-native-screenshot-prevent/TestNativeScreenshotPreventDemo.tsx
+++ b/react-native-screenshot-prevent/TestNativeScreenshotPreventDemo.tsx
@@ -1,0 +1,216 @@
+import {
+  Tester,
+  Filter,
+  TestSuite,
+  TestCase as _TestCase,
+} from '@rnoh/testerino';
+import React, {useState, useEffect} from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  Text,
+  Alert,
+  FlatList,
+  SafeAreaView,
+  StatusBar,
+  Linking,
+  TouchableOpacity,
+  Button,
+} from 'react-native';
+import RNScreenshotPrevent, {
+  addListener,
+} from '@react-native-oh-tpl/react-native-screenshot-prevent';
+
+type TesterSkipProp =
+  | {
+      android: string | boolean;
+      harmony: TesterHarmonySkipProp;
+    }
+  | string;
+
+function prepareSkipProp(skipProp: TesterSkipProp | undefined) {
+  return skipProp
+    ? typeof skipProp === 'string'
+      ? skipProp
+      : Platform.select({
+          android: skipProp?.android,
+          harmony: prepareHarmonySkipProp(skipProp?.harmony),
+        })
+    : undefined;
+}
+function Example({
+  itShould,
+  children,
+  skip,
+  tags,
+  modal,
+}: {
+  itShould: string;
+  children: any;
+  modal?: boolean;
+  skip?: TesterSkipProp;
+  tags?: TesterTag[];
+}) {
+  return (
+    <_TestCase
+      itShould={itShould}
+      modal={modal}
+      tags={tags}
+      skip={prepareSkipProp(skip)}>
+      {children}
+    </_TestCase>
+  );
+}
+const TestCase = {
+  Example: Example,
+};
+
+export function TestNativeScreenshotPreventDemo({filter}: {filter: Filter}) {
+  const subscriptionRef = React.useRef({});
+  const [text, setText] = React.useState('');
+  const handleClick1 = () => {
+    RNScreenshotPrevent.enabled(true);
+  };
+  const handleClick2 = () => {
+    RNScreenshotPrevent.enabled(false);
+  };
+  const handleClick3 = () => {
+    const subscription = addListener(() => {
+      setText('监听到截屏操作');
+    });
+    subscriptionRef.current = subscription;
+  };
+  const handleClick4 = () => {
+    const TAG2 = '测试事件监听RN侧';
+    console.info(TAG2, JSON.stringify(subscriptionRef));
+    subscriptionRef.current.remove();
+    setText('');
+  };
+
+  return (
+    <Tester style={styles.container}>
+      <ScrollView style={{flex: 1}}>
+        <TestSuite name="React Native Screenshot Prevent">
+          <TestCase.Example itShould="测试enabled(true)方法">
+            <View style={styles.inputpart}>
+              <Button
+                title="点击测试enable,开启禁止截屏与录屏功能"
+                onPress={handleClick1}></Button>
+            </View>
+          </TestCase.Example>
+          <TestCase.Example itShould="测试enabled(false)方法">
+            <View style={styles.inputpart}>
+              <Button
+                title="点击测试enable,关闭禁止截屏与录屏功能"
+                onPress={handleClick2}></Button>
+            </View>
+          </TestCase.Example>
+          <TestCase.Example itShould="测试addListener方法1">
+            <View style={styles.inputpart}>
+              <Button
+                title="点击测试addListener,开启截屏监听"
+                onPress={handleClick3}></Button>
+            </View>
+            <View style={styles.outputpart}>
+              <Text>
+                说明：点击按钮注册回调函数，当截屏时，：后面有文字提示---：
+                {text}
+              </Text>
+            </View>
+          </TestCase.Example>
+          <TestCase.Example itShould="测试addListener方法2">
+            <View style={styles.inputpart}>
+              <Button
+                title="点击测试addListener,关闭截屏监听"
+                onPress={handleClick4}></Button>
+            </View>
+          </TestCase.Example>
+        </TestSuite>
+      </ScrollView>
+    </Tester>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#333',
+  },
+  inputpart: {
+    marginBottom: 10,
+  },
+  output: {},
+  url: {
+    color: 'red',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  phone: {
+    color: 'green',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  email: {
+    color: 'blue',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  name: {
+    color: 'purple',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  username: {
+    color: 'orange',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  magicNumber: {
+    color: 'pink',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  hashTag: {
+    color: '#009f5d',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  idnumber: {
+    color: '#8cc540',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  idnumber2: {
+    color: '#880000',
+    fontFamily: 'Times',
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: ('bold', '700'),
+  },
+  fontstyle: {
+    fontSize: 32,
+    fontWeight: 600,
+  },
+  buttomMargin: {
+    width: '100%',
+    height: 60,
+  },
+});


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
该demo覆盖了RNScreenshotPrevent.enabled(true)、RNScreenshotPrevent.enabled(false)以及RNScreenshotPrevent.addListener接口的测试用例，RNScreenshotPrevent.enableSecureView()、RNPreventScreenshot.enableSecureView(imgUri)及RNScreenshotPrevent.disableSecureView()接口做遗留，暂未覆盖
本次修改要点：
+ 新增新增react-native-screenshot-prevent的demo

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)