### PR TITLE
test: 修改react-native-tab-navigator测试demo

### DIFF
--- a/react-native-tab-navigator/TabNavigatorTest.tsx
+++ b/react-native-tab-navigator/TabNavigatorTest.tsx
@@ -8,87 +8,89 @@ const PROFILE_IMAGE = [require('../assets/tab-navigator/profile_unselected.svg')
 
 export function TabNavigatorTest() {
     return (
-        <Tester>
-            <TestSuite name="TabNavigator">
+        <View style={{ flex: 1, paddingVertical: 48 }}>
+            <Tester>
                 <ScrollView>
-                    <TestCase itShould="Test sceneStyle and tabBarStyle prop of TabNavigator, set sceneStyle and tabBarStyle height 100">
-                        <View style={styles.container}>
-                            <TabNavigatorSceneAndTabBarStyleTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test sceneStyle and tabBarStyle prop of TabNavigator, set sceneStyle height 150 and set tabBarStyle height 50">
-                        <View style={styles.container}>
-                            <TabNavigatorSceneAndTabBarStyle1Test />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test tabBarShadowStyle prop of TabNavigator,set height 10 and backgroundColor[#32CD32]">
-                        <View style={styles.container}>
-                            <TabNavigatorTabBarShadowStyleTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test tabBarShadowStyle prop of TabNavigator,set height 5 and backgroundColor[#FFE4C4]">
-                        <View style={styles.container}>
-                            <TabNavigatorTabBarShadowStyle1Test />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test hidesTabTouch prop of TabNavigator, set hidesTabTouch true, no transparent effect when touch Tab">
-                        <View style={styles.container}>
-                            <TabNavigatorHidesTabTouchTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test title props of TabNavigator, Customize the titleStyle and selectedTitleStyle, set titleStyle[#8E2323], selectedTitleStyle[#E3CF57] of the first tab">
-                        <View style={styles.container}>
-                            <TabNavigatorTitlePropsTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test icon props of TabNavigator, Customize the icon of a tab and the icon when selected.">
-                        <View style={styles.container}>
-                            <TabNavigatorIconPropsTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test badgeText prop of TabNavigator, set badgeText 1">
-                        <View style={styles.container}>
-                            <TabNavigatorBadgeTextPropTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test renderBadge prop of TabNavigator, add a Custom Text Component">
-                        <View style={styles.container}>
-                            <TabNavigatorBadgePropTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test tabStyle prop of TabNavigator, set tabStyle backgroundColor[#E9C2A6]">
-                        <View style={styles.container}>
-                            <TabNavigatorTabStyleTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test tabStyle prop of TabNavigator, set tabStyle backgroundColor[#FFFACD]">
-                        <View style={styles.container}>
-                            <TabNavigatorTabStyle1Test />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test allowFontScaling prop of TabNavigator, set first tab allowFontScaling true, font size will change with system settings">
-                        <View style={styles.container}>
-                            <TabNavigatorFontScalingTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test accessible prop of TabNavigator, set first tab accessible false, the barrier-free function cannot obtain the tab component.">
-                        <View style={styles.container}>
-                            <TabNavigatorAccessibleTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="Test accessibilityLabel prop of TabNavigator, set accessibilityLabel[Custom AccessibilityLabel]">
-                        <View style={styles.container}>
-                            <TabNavigatorAccessibilityLabelTest />
-                        </View>
-                    </TestCase>
-                    <TestCase itShould="hide the tab bar">
-                        <View style={styles.container}>
-                            <TabNavigatorWithNoTabTest />
-                        </View>
-                    </TestCase>
+                    <TestSuite name="TabNavigator">
+                        <TestCase itShould="Test sceneStyle and tabBarStyle prop of TabNavigator, set sceneStyle and tabBarStyle height 100">
+                            <View style={styles.container}>
+                                <TabNavigatorSceneAndTabBarStyleTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test sceneStyle and tabBarStyle prop of TabNavigator, set sceneStyle height 150 and set tabBarStyle height 50">
+                            <View style={styles.container}>
+                                <TabNavigatorSceneAndTabBarStyle1Test />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test tabBarShadowStyle prop of TabNavigator,set height 10 and backgroundColor[#32CD32]">
+                            <View style={styles.container}>
+                                <TabNavigatorTabBarShadowStyleTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test tabBarShadowStyle prop of TabNavigator,set height 5 and backgroundColor[#FFE4C4]">
+                            <View style={styles.container}>
+                                <TabNavigatorTabBarShadowStyle1Test />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test hidesTabTouch prop of TabNavigator, set hidesTabTouch true, no transparent effect when touch Tab">
+                            <View style={styles.container}>
+                                <TabNavigatorHidesTabTouchTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test title props and selected prop of TabNavigator, Customize the titleStyle and selectedTitleStyle, set titleStyle[#8E2323], selectedTitleStyle[#E3CF57] of the first tab. When the first tab is selected, the color of the title changes to the selectedTitleStyle color.">
+                            <View style={styles.container}>
+                                <TabNavigatorTitlePropsTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test icon props of TabNavigator, Customize the icon of a tab and the icon when selected.">
+                            <View style={styles.container}>
+                                <TabNavigatorIconPropsTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test badgeText prop of TabNavigator, set badgeText 1">
+                            <View style={styles.container}>
+                                <TabNavigatorBadgeTextPropTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test renderBadge prop of TabNavigator, add a Custom Text Component">
+                            <View style={styles.container}>
+                                <TabNavigatorBadgePropTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test tabStyle prop of TabNavigator, set tabStyle backgroundColor[#E9C2A6]">
+                            <View style={styles.container}>
+                                <TabNavigatorTabStyleTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test tabStyle prop of TabNavigator, set tabStyle backgroundColor[#FFFACD]">
+                            <View style={styles.container}>
+                                <TabNavigatorTabStyle1Test />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test allowFontScaling prop of TabNavigator, set first tab allowFontScaling true, font size will change with system settings">
+                            <View style={styles.container}>
+                                <TabNavigatorFontScalingTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test accessible prop of TabNavigator, set first tab accessible false, the barrier-free function cannot obtain the tab component.">
+                            <View style={styles.container}>
+                                <TabNavigatorAccessibleTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="Test accessibilityLabel prop of TabNavigator, set accessibilityLabel[Custom AccessibilityLabel]">
+                            <View style={styles.container}>
+                                <TabNavigatorAccessibilityLabelTest />
+                            </View>
+                        </TestCase>
+                        <TestCase itShould="hide the tab bar">
+                            <View style={styles.container}>
+                                <TabNavigatorWithNoTabTest />
+                            </View>
+                        </TestCase>
+                    </TestSuite>
                 </ScrollView>
-            </TestSuite>
-        </Tester>
+            </Tester>
+        </View>
     );
 }
 
@@ -406,7 +408,7 @@ function TabNavigatorFontScalingTest() {
                 selectedTitleStyle={{ color: "#3496f0" }}
                 renderIcon={() => <Image source={HOME_IMAGE[0]} style={styles.iconSize} />}
                 renderSelectedIcon={() => <Image source={HOME_IMAGE[1]} style={styles.iconSize} />}
-                allowFontScaling={true}
+                allowFontScaling={false}
                 onPress={() => setSelectedTab('home')}>
                 <Home />
             </TabNavigator.Item>
@@ -431,8 +433,6 @@ function TabNavigatorAccessibleTest() {
                 selected={selectedTab === 'home'}
                 title="Home"
                 selectedTitleStyle={{ color: "#3496f0" }}
-                renderIcon={() => <Image source={HOME_IMAGE[0]} style={styles.iconSize} />}
-                renderSelectedIcon={() => <Image source={HOME_IMAGE[1]} style={styles.iconSize} />}
                 accessible={false}
                 onPress={() => setSelectedTab('home')}>
                 <Home />
@@ -441,8 +441,6 @@ function TabNavigatorAccessibleTest() {
                 selected={selectedTab === 'profile'}
                 title="Profile"
                 selectedTitleStyle={{ color: "#3496f0" }}
-                renderIcon={() => <Image source={PROFILE_IMAGE[0]} style={styles.iconSize} />}
-                renderSelectedIcon={() => <Image source={PROFILE_IMAGE[1]} style={styles.iconSize} />}
                 onPress={() => setSelectedTab('profile')}>
                 <Profile />
             </TabNavigator.Item>
@@ -470,6 +468,8 @@ function TabNavigatorAccessibilityLabelTest() {
                 selectedTitleStyle={{ color: "#3496f0" }}
                 renderIcon={() => <Image source={PROFILE_IMAGE[0]} style={styles.iconSize} />}
                 renderSelectedIcon={() => <Image source={PROFILE_IMAGE[1]} style={styles.iconSize} />}
+                accessible={false}
+                accessibilityLabel="Custom ProfileLabel accessible false"
                 onPress={() => setSelectedTab('profile')}>
                 <Profile />
             </TabNavigator.Item>


### PR DESCRIPTION
# Summary
- 优化demo布局，外层添加View组件使得页面头部区域不被上方状态栏挡住
- 优化测试demo，添加关于selected属性的测试描述

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
