### PR TITLE
test: 新增react-native-print测试demo

### DIFF
--- a/react-native-print/PrintDemo.tsx
+++ b/react-native-print/PrintDemo.tsx
@@ -1,0 +1,81 @@
+import React, {useState} from 'react';
+import {ScrollView, Button} from 'react-native';
+import {
+  pick,
+  DocumentPickerOptions,
+  isCancel,
+} from 'react-native-document-picker';
+import RNPrint from 'react-native-print';
+
+type DirType = 'documentDirectory' | 'cachesDirectory';
+
+interface DirOpt {
+  label: DirType;
+  selected: boolean;
+}
+
+export default function DocumentPickerDemo(): JSX.Element {
+  const [pickResult, setPickResult] = useState('');
+  const [allowMultiSelection, setAllowMultiSelection] = useState(true);
+  const [fileTypes, setFileTypes] = useState<string[]>([]);
+  const [dirUi, setDirui] = useState<Array<DirOpt>>([
+    {label: 'documentDirectory', selected: false},
+    {label: 'cachesDirectory', selected: false},
+  ]);
+  const copyTo = dirUi.find(d => d.selected)?.label;
+  const pickOpt: DocumentPickerOptions<'harmony'> = {
+    allowMultiSelection,
+    presentationStyle: 'overFullScreen',
+  };
+  if (copyTo) {
+    pickOpt.copyTo = copyTo;
+  }
+  if (fileTypes.length) {
+    pickOpt.type = fileTypes;
+  }
+  const pickFile = async () => {
+    try {
+      const res = await pick(pickOpt);
+      setPickResult(JSON.stringify(res));
+      return res;
+    } catch (err) {
+      console.log(err);
+      console.log('isCancel: ' + isCancel(err));
+    }
+  };
+
+  return (
+    <ScrollView>
+      <Button
+        title="本地url打印"
+        onPress={async () => {
+          const res = await pickFile();
+          RNPrint.print({
+            filePath: res[0].uri,
+            jobName: 'huawei',
+          });
+        }}
+      />
+      <Button
+        title="远程uri打印"
+        onPress={() => {
+          RNPrint.print({
+            filePath:
+              'https://gips2.baidu.com/it/u=2055042668,1190219470&fm=3028&app=3028&f=JPEG&fmt=auto?w=960&h=1280',
+            jobName: 'huawei1',
+          });
+        }}
+      />
+      <Button
+        title="本地url打印"
+        onPress={async () => {
+          const res = await pickFile();
+          RNPrint.print({
+            filePath: res[0].uri,
+            jobName: 'huawei',
+          });
+        }}
+      />
+    </ScrollView>
+  );
+}

--- a/react-native-print/test/PrintTest.tsx
+++ b/react-native-print/test/PrintTest.tsx
@@ -1,0 +1,97 @@
+import {Tester, TestSuite, TestCase} from '@rnoh/testerino';
+import React, {useState} from 'react';
+import {
+  ScrollView,
+  Button,
+} from 'react-native';
+import {
+  pick,
+  DocumentPickerOptions,
+  isCancel,
+} from 'react-native-document-picker';
+import RNPrint from 'react-native-print';
+
+type DirType = 'documentDirectory' | 'cachesDirectory';
+
+interface DirOpt {
+  label: DirType;
+  selected: boolean;
+}
+
+export default function DocumentPickerDemo(): JSX.Element {
+  const [pickResult, setPickResult] = useState('');
+  const [allowMultiSelection, setAllowMultiSelection] = useState(true);
+  const [fileTypes, setFileTypes] = useState<string[]>([]);
+  const [dirUi, setDirui] = useState<Array<DirOpt>>([
+    {label: 'documentDirectory', selected: false},
+    {label: 'cachesDirectory', selected: false},
+  ]);
+  const copyTo = dirUi.find(d => d.selected)?.label;
+  const pickOpt: DocumentPickerOptions<'harmony'> = {
+    allowMultiSelection,
+    presentationStyle: 'overFullScreen',
+  };
+  if (copyTo) {
+    pickOpt.copyTo = copyTo;
+  }
+  if (fileTypes.length) {
+    pickOpt.type = fileTypes;
+  }
+  const pickFile = async () => {
+    try {
+      const res = await pick(pickOpt);
+      setPickResult(JSON.stringify(res));
+      return res;
+    } catch (err) {
+      console.log(err);
+      console.log('isCancel: ' + isCancel(err));
+    }
+  };
+
+  return (
+    <ScrollView>
+      <Tester>
+        <TestSuite name="filePath">
+          <TestCase tags={['C_API']} itShould="filePath(本地uri打印)">
+            <Button
+              title="本地url打印"
+              onPress={async () => {
+                const res = await pickFile();
+                RNPrint.print({
+                  filePath: res[0].uri,
+                  jobName: 'huawei',
+                });
+              }}
+            />
+          </TestCase>
+          <TestCase tags={['C_API']} itShould="filePath(远程uri打印,filePath:'https://gips2.baidu.com/it/u=2055042668,1190219470&fm=3028&app=3028&f=JPEG&fmt=auto?w=960&h=1280')">
+            <Button
+              title="远程uri打印"
+              onPress={() => {
+                RNPrint.print({
+                  filePath:
+                    'https://gips2.baidu.com/it/u=2055042668,1190219470&fm=3028&app=3028&f=JPEG&fmt=auto?w=960&h=1280',
+                  jobName: 'huawei1',
+                });
+              }}
+            />
+          </TestCase>
+        </TestSuite>
+        <TestSuite name="jobName">
+          <TestCase tags={['C_API']} itShould="jobName(打印作业的名称，是打印文件在沙箱里面的名称，无法显示出来)">
+            <Button
+              title="本地url打印"
+              onPress={async () => {
+                const res = await pickFile();
+                RNPrint.print({
+                  filePath: res[0].uri,
+                  jobName: 'huawei',
+                });
+              }}
+            />
+          </TestCase>
+        </TestSuite>
+      </Tester>
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

新增了react-native-print的测试demo和test。
新增了print接口中filePath、jobName两个参数的demo。
参数filePath包括远程uri打印和本地uri打印的demo

## Test Plan

![image](https://github.com/user-attachments/assets/5685a890-c856-4018-94b0-5cc5da70a621)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


