### PR TITLE
test：新增react-native-mertial-dropdown测试用例和demo

### DIFF
--- a/react-native-material-dropdown/DropDownDemo.tsx
+++ b/react-native-material-dropdown/DropDownDemo.tsx
@@ -1,246 +1,108 @@
 import React, { Component } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { AppRegistry, Text, View } from 'react-native';
+import { TextField } from 'react-native-material-textfield';
 import { Dropdown } from 'react-native-material-dropdown';
-import {
-  Tester,
-  TestSuite,
-  TestCase
-} from '@rnoh/testerino';
 
-export class Example extends Component {
-  constructor(props) {
-    super(props);
 
-    this.onChangeText = this.onChangeText.bind(this);
+export class DropDownDemo extends Component {
+    constructor(props) {
+      super(props);
 
-    this.codeRef = this.updateRef.bind(this, 'code');
-    this.nameRef = this.updateRef.bind(this, 'name');
-    this.sampleRef = this.updateRef.bind(this, 'sample');
-    this.typographyRef = this.updateRef.bind(this, 'typography');
+      this.onChangeText = this.onChangeText.bind(this);
 
-    this.state = {
-      sample: 'The quick brown fox jumps over the lazy dog',
-      typography: 'value',
-      name: 'Cyan',
-      code: 'A700',
-    };
-  }
+      this.codeRef = this.updateRef.bind(this, 'code');
+      this.nameRef = this.updateRef.bind(this, 'name');
+      this.sampleRef = this.updateRef.bind(this, 'sample');
+      this.typographyRef = this.updateRef.bind(this, 'typography');
 
-  onChangeText(text) {
-    ['name', 'code', 'sample', 'typography']
-      .map((name) => ({ name, ref: this[name] }))
-      .filter(({ ref }) => ref && ref.isFocused())
-      .forEach(({ name, ref }) => {
-        this.setState({ [name]: text });
-      });
+      this.state = {
+        sample: 'The quick brown fox jumps over the lazy dog',
+        typography: 'Headline',
+        name: 'Cyan',
+        code: 'A700',
+      };
+    }
 
-  }
+    onChangeText(text) {
+      ['name', 'code', 'sample', 'typography']
+        .map((name) => ({ name, ref: this[name] }))
+        .filter(({ ref }) => ref && ref.isFocused())
+        .forEach(({ name, ref }) => {
+          this.setState({ [name]: text });
+        });
+    }
 
-  updateRef(name, ref) {
-    this[name] = ref;
-  }
+    updateRef(name, ref) {
+      this[name] = ref;
+    }
 
-  render() {
-    let { typography, name, code, sample } = this.state;
-    let textStyle = [
-      styles.text,
-      styles[typography],
-      styles[name + code],
-    ];
+    render() {
+      let { typography, name, code, sample } = this.state;
 
-    return (
-      <View style={styles.screen}>
-        <Tester style={{ flex: 1, backgroundColor: 'black' }}>
-          <ScrollView >
-            <TestSuite name="DropDown test">
-              <View style={styles.container}>
-                <TestCase
-                  itShould="TestCase01 DropDown data and value "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography} //选中值
-                        data={typographyData} //item 条目值
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase02 DropDown textColor "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        textColor='rgba(255, 5, 0, .87)' // 被选中的vlue颜色值
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase03 DropDown itemColor "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        textColor='rgba(0, 5, 0, .87)' // 被选中的vlue颜色值
-                        itemColor='rgba(0, 100, 0, .87)' //下拉列表里面的item颜色
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase04 DropDown selectedItemColor "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        textColor='rgba(255, 100, 0, .87)' // 被选中的vlue颜色值
-                        itemColor='rgba(0, 100, 0, .87)' //下拉列表里面的item颜色
-                        selectedItemColor='rgba(255, 100, 0, .87)'//下拉列表里面的item被选中的颜色
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase05 DropDown dropdownPosition "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        dropdownPosition='10' //点击弹出下拉列表的位置
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase06 DropDown label "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        label='...我是标签....' //下拉列表默认标签
-                        onChangeText={(e) => {
-                          this.onChangeText(e);
-                          setState(true);
-                        }}
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
-                />
-                <TestCase
-                  itShould="TestCase07 DropDown itemCount "
-                  tags={['C_API']}
-                  initialState={undefined as any}
-                  arrange={({ setState }) => {
-                    return (
-                      <Dropdown
-                        ref={this.typographyRef}
-                        value={typography}
-                        data={typographyData}
-                        itemCount='2' //点击弹出下拉列表显示的item的数量，默认4个
-                        dropdownPosition='4'
-                      />
-                    );
-                  }}
-                  assert={({ state, expect }) => {
-                    expect(state).to.be.true;
-                  }}
+      let textStyle = [
+        styles.text,
+        styles[typography],
+        styles[name + code],
+      ];
+
+      return (
+        <View style={styles.screen}>
+          <View style={styles.container}>
+            <TextField
+              ref={this.sampleRef}
+              value={sample}
+              onChangeText={this.onChangeText}
+              label='Sample text'
+              multiline={true}
+            />
+
+            <Dropdown
+              ref={this.typographyRef}
+              value={typography}
+              onChangeText={this.onChangeText}
+              label='Typography'
+              data={typographyData}
+            />
+
+            <View style={{ flexDirection: 'row' }}>
+              <View style={{ flex: 1 }}>
+                <Dropdown
+                  ref={this.nameRef}
+                  value={name}
+                  onChangeText={this.onChangeText}
+                  label='Color name'
+                  data={colorNameData}
                 />
               </View>
-            </TestSuite>
-          </ScrollView>
-        </Tester>
-      </View>
-    );
+
+              <View style={{ width: 96, marginLeft: 8 }}>
+                <Dropdown
+                  ref={this.codeRef}
+                  value={code}
+                  onChangeText={this.onChangeText}
+                  label='Color code'
+                  data={colorCodeData}
+                  propsExtractor={({ props }, index) => props}
+                />
+              </View>
+            </View>
+          </View>
+
+          <View style={[styles.container, styles.textContainer]}>
+            <Text style={textStyle}>{sample}</Text>
+          </View>
+        </View>
+      );
+    }
   }
-}
 
 
 const styles = {
-  TextInput: {
-    height: 40,
-    borderColor: '#ccc',
-    borderWidth: 1,
-    borderRadius: 4,
-    width: '90%',
-  },
-  btn: {
-    borderRadius: 10,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 10,
-    margin: 10,
-    backgroundColor: 'blue',
-  },
-  btnText: { fontWeight: 'bold', color: '#fff', fontSize: 20 },
-
   screen: {
     flex: 1,
     padding: 4,
     paddingTop: 56,
-    backgroundColor: 'black',
+    backgroundColor: '#E8EAF6',
   },
 
   container: {
@@ -292,11 +154,24 @@ const styles = {
 };
 
 const typographyData = [
-  { value: 'value' },
-  { value: 'textColor'},
-  { value: 'itemColor' },
-  { value: 'selectedItemColor' },
-  { value: 'DropDown Postion' },
-  { value: 'DropDown label' },
-  { value: 'itemCount' },
+  { value: 'Display2', label: 'Display 2' },
+  { value: 'Display1', label: 'Display 1' },
+  { value: 'Headline' },
+  { value: 'Title' },
+  { value: 'Subheading' },
+  { value: 'Body' },
+  { value: 'Caption' },
+];
+
+const colorNameData = [
+  { value: 'Blue' },
+  { value: 'Teal' },
+  { value: 'Cyan' },
+];
+
+const colorCodeData = [
+  { value: '900', props: { disabled: true } },
+  { value: '700' },
+  { value: 'A700' },
+  { value: 'A400' },
 ];

--- a/react-native-material-dropdown/test/DropDownTest.tsx
+++ b/react-native-material-dropdown/test/DropDownTest.tsx
@@ -1,0 +1,336 @@
+import React, { Component } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import { Dropdown } from 'react-native-material-dropdown';
+import {
+  Tester,
+  TestSuite,
+  TestCase
+} from '@rnoh/testerino';
+
+export class DropDownTest extends Component {
+  constructor(props) {
+    super(props);
+
+    this.onChangeText = this.onChangeText.bind(this);
+
+    this.codeRef = this.updateRef.bind(this, 'code');
+    this.nameRef = this.updateRef.bind(this, 'name');
+    this.sampleRef = this.updateRef.bind(this, 'sample');
+    this.typographyRef = this.updateRef.bind(this, 'typography');
+
+    this.state = {
+      sample: 'The quick brown fox jumps over the lazy dog',
+      typography: 'value',
+      name: 'Cyan',
+      code: 'A700',
+    };
+  }
+
+
+  onChangeText(text) {
+    ['name', 'code', 'sample', 'typography']
+      .map((name) => ({ name, ref: this[name] }))
+      .filter(({ ref }) => ref && ref.isFocused())
+      .forEach(({ name, ref }) => {
+        this.setState({ [name]: text });
+      });
+
+  }
+
+  updateRef(name, ref) {
+    this[name] = ref;
+  }
+
+  render() {
+    let { typography, name, code, sample } = this.state;
+    let textStyle = [
+      styles.text,
+      styles[typography],
+      styles[name + code],
+    ];
+
+    return (
+      <View style={styles.screen}>
+        <Tester style={{ flex: 1, backgroundColor: 'black' }}>
+          <ScrollView>
+            <TestSuite name="DropDown test">
+              <View style={styles.container}>
+                <TestCase
+                  itShould="TestCase01 DropDown data and value "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography} //选中值
+                        data={typographyData} //item 条目值
+                        label='i am label' //标签
+                        error='i am error' // 错误提示语
+                        animationDuration={500} //显示dropdown动画时长
+                        fontSize='25' //字体大小
+                        labelFontSize={25} //标签字体大小
+                        shadeOpacity={0.99}//按下阴影透明度
+                        rippleOpacity={0.5} //波纹透明度
+                        textColor='blue'//被选中的value颜色
+                        itemColor='red'//itemt条目颜色
+                        selectedItemColor='green'//item被选中颜色
+                        itemPadding='5'//item条目内边距
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase02 DropDown textColor "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        textColor='rgba(255, 5, 0, .87)' // 被选中的vlue颜色值
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase03 DropDown itemColor "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        textColor='rgba(0, 5, 0, .87)' // 被选中的vlue颜色值
+                        itemColor='rgba(0, 100, 0, .87)' //下拉列表里面的item颜色
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase04 DropDown selectedItemColor "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        textColor='rgba(255, 100, 0, .87)' // 被选中的vlue颜色值
+                        itemColor='rgba(0, 100, 0, .87)' //下拉列表里面的item颜色
+                        selectedItemColor='rgba(255, 100, 0, .87)'//下拉列表里面的item被选中的颜色
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase05 DropDown dropdownPosition "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        dropdownPosition='10' //点击弹出下拉列表的位置
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase06 DropDown label "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        label='...我是标签....' //下拉列表默认标签
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase07 DropDown baseColor "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        baseColor='yellow'//条目按下颜色
+                        onChangeText={(e) => {
+                          this.onChangeText(e);
+                          setState(true);
+                        }}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+                <TestCase
+                  itShould="TestCase08 DropDown itemCount "
+                  tags={['C_API']}
+                  initialState={undefined as any}
+                  arrange={({ setState }) => {
+                    return (
+                      <Dropdown
+                        ref={this.typographyRef}
+                        value={typography}
+                        data={typographyData}
+                        itemCount={2} //点击弹出下拉列表显示的item的数量，默认4个
+                        dropdownPosition={4}
+                      />
+                    );
+                  }}
+                  assert={({ state, expect }) => {
+                    expect(state).to.be.true;
+                  }}
+                />
+              </View>
+            </TestSuite>
+          </ScrollView>
+        </Tester>
+      </View>
+    );
+  }
+}
+
+
+const styles = {
+  TextInput: {
+    height: 40,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 4,
+    width: '90%',
+  },
+  btn: {
+    borderRadius: 10,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 10,
+    margin: 10,
+    backgroundColor: 'blue',
+  },
+  btnText: { fontWeight: 'bold', color: '#fff', fontSize: 20 },
+
+  screen: {
+    flex: 1,
+    padding: 4,
+    paddingTop: 10,
+    backgroundColor: 'black',
+  },
+
+  container: {
+    marginHorizontal: 4,
+    marginVertical: 8,
+    paddingHorizontal: 8,
+  },
+
+  text: {
+    textAlign: 'center',
+  },
+
+  textContainer: {
+    backgroundColor: 'white',
+    borderRadius: 2,
+    padding: 16,
+    elevation: 1,
+    shadowRadius: 1,
+    shadowOpacity: 0.3,
+    justifyContent: 'center',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+  },
+
+  Display2: { fontSize: 45 },
+  Display1: { fontSize: 34 },
+  Headline: { fontSize: 24 },
+  Title: { fontSize: 20, fontWeight: '500' },
+  Subheading: { fontSize: 16 },
+  Body: { fontSize: 14 },
+  Caption: { fontSize: 12 },
+
+  Blue900: { color: '#0D47A1' },
+  Blue700: { color: '#1976D2' },
+  BlueA700: { color: '#2962FF' },
+  BlueA400: { color: '#2979FF' },
+
+  Teal900: { color: '#004D40' },
+  Teal700: { color: '#00796B' },
+  TealA700: { color: '#00BFA5' },
+  TealA400: { color: '#1DE9B6' },
+
+  Cyan900: { color: '#006064' },
+  Cyan700: { color: '#0097A7' },
+  CyanA700: { color: '#00E5FF' },
+  CyanA400: { color: '#00B8D4' },
+};
+
+const typographyData = [
+  { value: 'value' },
+  { value: 'textColor' },
+  { value: 'itemColor' },
+  { value: 'selectedItemColor' },
+  { value: 'DropDown Postion' },
+  { value: 'DropDown label' },
+  { value: 'itemCount' },
+];


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响-->
请解释此次更改的 **动机**，以下是一些帮助您的要点：
- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
 这个demo测试，不涉及issues
- 这个功能是什么？
 这个PR是为了适配react-native-mertial-dropdown HMOS系统demo和test验证
- 您是如何实现解决方案的？
参照react-native-mertial-dropdown源码修改适配后demo验证
- 这个更改影响了库的哪些部分？
参照react-native-mertial-dropdown源码修改适配demo验证


## Test Plan
展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
demo测试路径：https://github.com/MyAndroidNetZWJ/RNOHDCS/tree/main/react-native-material-dropdown

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->
- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [X] 更新了 JS/TS 代码 