### PR TITLE
test:修改react-native-permissions的测试用例、demo

### DIFF
--- a/react-native-permissions/demo/demo.tsx
+++ b/react-native-permissions/demo/demo.tsx
@@ -1,0 +1,69 @@
+import { ScrollView, StyleSheet, View, Text, Button } from "react-native";
+import React from "react";
+import RTNPermissions, { Permission } from "react-native-permissions";
+const permissionNormal: Permission[] = [
+  "ohos.permission.APPROXIMATELY_LOCATION",
+  "ohos.permission.CAMERA",
+  "ohos.permission.MICROPHONE",
+  "ohos.permission.READ_CALENDAR",
+  "ohos.permission.WRITE_CALENDAR",
+  "ohos.permission.ACTIVITY_MOTION",
+  "ohos.permission.READ_HEALTH_DATA",
+  "ohos.permission.DISTRIBUTED_DATASYNC",
+  "ohos.permission.READ_MEDIA",
+  "ohos.permission.MEDIA_LOCATION",
+  "ohos.permission.ACCESS_BLUETOOTH",
+];
+export function PermissionTest() {
+  return (
+    <View style={styles.sectionContainer}>
+      <Button
+        title="查询相机权限"
+        onPress={async () => {
+          let check = await RTNPermissions.check("ohos.permission.CAMERA");
+          console.info("RTNPermissions===== check", check);
+        }}
+      />
+      <Button
+        title="设置相机权限"
+        onPress={async () => {
+          let request = await RTNPermissions.request("ohos.permission.CAMERA");
+          console.info("RTNPermissions===== request", request);
+        }}
+      />
+      <Button
+        title={"查询多个权限"}
+        onPress={async () => {
+          let checkMultiple = await RTNPermissions.checkMultiple(
+            permissionNormal
+          );
+          console.info("RTNPermissions===== checkMultiple", checkMultiple);
+        }}
+      />
+      <Button
+        title={"设置多个权限"}
+        onPress={async () => {
+          let requestMultiple = await RTNPermissions.requestMultiple(
+            permissionNormal
+          );
+          console.info("RTNPermissions===== requestMultiple", requestMultiple);
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionContainer: {
+    marginTop: 32,
+    paddingHorizontal: 24,
+  },
+  view: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-evenly",
+    flexWrap: "wrap",
+    margin: 5,
+  },
+});

--- a/react-native-permissions/testCase/TestCase.tsx
+++ b/react-native-permissions/testCase/TestCase.tsx
@@ -1,8 +1,4 @@
 import React, { useRef, useState } from 'react';
-
-
-
-
 import {
     StyleSheet,
     View,
@@ -15,12 +11,6 @@ import {
 } from 'react-native';
 import { Tester, TestSuite, TestCase } from '@rnoh/testerino';
 import RTNPermissions, { Permission, NotificationsResponse } from "@react-native-oh-tpl/react-native-permissions";
-
-
-
-
-
-
 export const PermissionTest = () => {
     const permissionNormal: Permission[] = [
         "ohos.permission.APPROXIMATELY_LOCATION",
@@ -40,8 +30,6 @@ export const PermissionTest = () => {
     const [camer, setCamer] = useState("还未获取")
     const [checkNotifications, setCheckNotifications] = useState<string>("还未获取")
     const [checkMultiple, setCheckMultiple] = useState("还未获取")
-
-
     return (
         <Tester>
             <ScrollView>
@@ -233,9 +221,6 @@ export const PermissionTest = () => {
                             expect(state).to.be.true;
                         }}
                     />
-
-
-
 
                 </TestSuite>
 


### PR DESCRIPTION
# Summary

修改react-native-permissions的示例demo
已测的接口：check、checkNotifications、openSettings、request、requestNotifications、checkMultiple、requestMultiple
未测的接口：checkLocationAccuracy、requestLocationAccuracy、openPhotoPicker

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
