### PR TITLE
test: 修改 react-native-gesture-handler 的测试demo中DrawerLayout场景

### DIFF
--- a/react-native-gesture-handler/DrawerLayout.tsx
+++ b/react-native-gesture-handler/DrawerLayout.tsx
@@ -23,7 +23,7 @@ import { NewApiTest, OldApiTest, SharedAPITest } from './src';
 
 type RootViewMode = 'Component' | 'HOC';
 
-const DEV_MODE = false;
+const IS_HIDE: boolean = false;
 
 function App({ }): JSX.Element | null {
   const [rootViewMode, setRootViewMode] = useState<RootViewMode>('Component');
@@ -86,10 +86,16 @@ function Tests() {
             <Button title="设置 statusBarAnimation('none')" onPress={() => { setStatusBarAnimation('none') }}></Button>
           </View>
           <View style={{ height: 50, marginTop: 12 }}>
-            <Button title="设置 hideStatusBar('true')" onPress={() => { setIsHide(true); }}></Button>
-          </View>
-          <View style={{ height: 50, marginTop: 12 }}>
-            <Button title="设置 hideStatusBar('false')" onPress={() => { setIsHide(false); }}></Button>
+            <Button title="设置 hideStatusBar('true or false')" onPress={() => {
+              if (this.IS_HIDE) {
+                this.IS_HIDE = false;
+                setIsHide(false);
+              } else {
+                setIsHide(true);
+                this.IS_HIDE = true;
+              }
+              }}>
+            </Button>
           </View>
           <View style={{ height: 50, marginTop: 12 }}>
             <Button title="设置 edgeWidth('300')" onPress={() => { setEdgeWidth(300); }}></Button>


### PR DESCRIPTION
# Summary

- 修改了DrawerLayout模块中隐藏显示状态栏属性。

## Test Plan

![image](https://github.com/user-attachments/assets/e3da45c1-1143-4a47-959b-4499d36129cb)
![image](https://github.com/user-attachments/assets/fed55b75-72fa-4cfd-9241-2766060a2e49)
![image](https://github.com/user-attachments/assets/656af790-a7ad-4060-8b94-1eb264136e61)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
