### PR TITLE
test: 新增react-native-mlkit-ocr测试demo，新增react-native-mlkit-ocr测试用例(#801)

### DIFF
--- a/react-native-mlkit-ocr/Test/OcrTest.tsx
+++ b/react-native-mlkit-ocr/Test/OcrTest.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { TestSuite, TestCase, Tester } from '@rnoh/testerino';
+import {
+    StyleSheet,
+    View,
+    TouchableHighlight,
+    SafeAreaView,
+    Text,
+    ActivityIndicator,
+} from 'react-native';
+import MlkitOcr, { MlkitOcrResult } from 'react-native-mlkit-ocr';
+
+const PALETTE = {
+    REACT_CYAN_LIGHT: 'hsl(193, 95%, 68%)',
+    REACT_CYAN_DARK: 'hsl(193, 95%, 30%)',
+}
+
+function Button({ label, onPress }: { onPress: () => void; label: string }) {
+    return (
+        <TouchableHighlight
+            underlayColor={PALETTE.REACT_CYAN_DARK}
+            style={{
+                paddingVertical: 6,
+                paddingHorizontal: 12,
+                backgroundColor: PALETTE.REACT_CYAN_LIGHT,
+                borderWidth: 2,
+                borderColor: PALETTE.REACT_CYAN_DARK,
+            }}
+            onPress={onPress}>
+            <Text style={{ color: 'black', fontWeight: 'bold', fontSize: 16 }}>
+                {label}
+            </Text>
+        </TouchableHighlight>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+    },
+    scroll: {
+        flex: 1,
+        width: '100%',
+        borderColor: '#ccc',
+        borderWidth: 2,
+        height: '70%',
+    },
+});
+
+export const OcrTest = () => {
+    const [loading, setLoading] = React.useState<boolean>(false);
+    const [result, setResult] = React.useState<MlkitOcrResult | undefined>();
+
+    if (loading) {
+        return (
+            <SafeAreaView style={styles.container}>
+                <ActivityIndicator />
+            </SafeAreaView>
+        );
+    }
+    return (
+        <SafeAreaView style={styles.container}>
+            <View style={{ flex: 1 }}>
+
+                {Array.isArray(result) && result?.length && (
+                    <View
+                        style={styles.scroll}
+                    >
+                        {result?.map((block) => {
+                            console.log("=================result>", JSON.stringify(result));
+                            console.log("=================block>", JSON.stringify(block));
+
+                            return block.lines.map((line) => {
+                                return (
+                                    <View
+                                        key={line.text}
+                                        style={{
+                                            backgroundColor: '#ccccccaf',
+                                        }}
+                                    >
+                                        <Text style={{ fontSize: 10 }}>{line.text}</Text>
+                                    </View>
+                                );
+                            });
+                        })}
+                    </View>
+                )}
+
+                <TestSuite name="@react-native-oh-tpl/react-native-mlkit-ocr">
+                    <TestCase
+                        key={1}
+                        itShould={'识别网络照片'}
+                        tags={['C_API']}
+                        initialState={false}
+                        arrange={({ setState }) => {
+                            return (
+                                <View style={{ flex: 1 }}>
+                                    <Button
+                                        label="识别网络照片"
+                                        onPress={() => {
+                                            MlkitOcr.detectFromUri('https://res.vmallres.com//uomcdn/CN/pms/202407/E3B48F7290631FAF341FDB09CF907F03.jpg').then(res => {
+                                                setTimeout(() => {
+                                                    setResult(res)
+                                                    setState(!!res)
+
+                                                    console.log("================uri=res", JSON.stringify(res))
+                                                }, 1000)
+                                            }).catch(err => {
+                                                console.log("=========", err);
+
+                                            })
+                                        }}
+                                    />
+                                </View>
+                            );
+                        }}
+                        assert={async ({ expect, state }) => {
+                            expect(state).to.be.true;
+                        }}
+                    />
+                    <TestCase
+                        key={2}
+                        itShould={'识别本地照片'}
+                        tags={['C_API']}
+                        initialState={false}
+                        arrange={({ setState }) => {
+                            return (
+                                <View style={{ flex: 1 }}>
+                                    <Button
+                                        label="识别本地照片"
+                                        onPress={() => {
+                                            MlkitOcr.detectFromFile('file://docs/storage/Users/currentUser/test/1.jpg').then(res => {
+                                                setTimeout(() => {
+                                                    setResult(res)
+                                                    setState(!!res)
+                                                    console.log("================file=res", JSON.stringify(res))
+                                                }, 1000)
+                                            }).catch(err => {
+                                                console.log("=========", err);
+
+                                            })
+                                        }}
+                                    />
+                                </View>
+                            );
+                        }}
+                        assert={async ({ expect, state }) => {
+                            expect(state).to.be.true;
+                        }}
+                    />
+
+                </TestSuite>
+
+            </View>
+        </SafeAreaView>
+    );
+
+};
+

--- a/react-native-mlkit-ocr/TestOcrExample.tsx
+++ b/react-native-mlkit-ocr/TestOcrExample.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable react-native/no-inline-styles */
+import * as React from 'react';
+import {
+    StyleSheet,
+    View,
+    Button,
+    SafeAreaView,
+    ScrollView,
+    Text,
+    Dimensions,
+    ActivityIndicator,
+} from 'react-native';
+import MlkitOcr, { MlkitOcrResult } from 'react-native-mlkit-ocr';
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+    },
+    scroll: {
+        flex: 1,
+        width: '100%',
+        borderColor: '#ccc',
+        borderWidth: 2,
+    },
+});
+export const OcrTest = () => {
+    const [loading, setLoading] = React.useState<boolean>(false);
+    const [result, setResult] = React.useState<MlkitOcrResult | undefined>();
+
+    if (loading) {
+        return (
+            <SafeAreaView style={styles.container}>
+                <ActivityIndicator />
+            </SafeAreaView>
+        );
+    }
+    return (
+        <SafeAreaView style={styles.container}>
+            {Array.isArray(result) && result?.length && (
+                <ScrollView
+                    contentContainerStyle={{
+                        alignItems: 'stretch',
+                        padding: 20,
+                        height: Dimensions.get('window').height,
+                    }}
+                    showsVerticalScrollIndicator
+                    style={styles.scroll}
+                >
+                    {result?.map((block) => {
+                        return block.lines.map((line) => {
+                            return (
+                                <View
+                                    key={line.text}
+                                    style={{
+                                        backgroundColor: '#ccccccaf',
+                                    }}
+                                >
+                                    <Text style={{ fontSize: 10 }}>{line.text}</Text>
+                                </View>
+                            );
+                        });
+                    })}
+                </ScrollView>
+            )}
+
+            <Button
+                title="识别网络照片"
+                onPress={() => {
+                    MlkitOcr.detectFromUri('https://res.vmallres.com//uomcdn/CN/pms/202407/E3B48F7290631FAF341FDB09CF907F03.jpg').then(res => {
+                        setTimeout(() => {
+                            setResult(res)
+                            console.log("================uri=res", JSON.stringify(res))
+                        }, 1000)
+                    }).catch(err => {
+                        console.log("=========err", err);
+                    })
+                }}
+            />
+            <Button
+                title="识别本地照片"
+                onPress={() => {
+                    MlkitOcr.detectFromFile('file://docs/storage/Users/currentUser/test/1.jpg').then(res => {
+                        setTimeout(() => {
+                            setResult(res)
+                            console.log("================file=res", JSON.stringify(res))
+                        }, 1000)
+                    }).catch(err => {
+                        console.log("=========err", err);
+                    })
+                }}
+            />
+        </SafeAreaView>
+    );
+}
+


### PR DESCRIPTION
# Summary

新增react-native-mlkit-ocr测试demo和测试用例
1. 新增测试demo和测试用例
2. 新增测试API包含2个方法函数
detectFromUri(uri: string)：传入图片的 在线地址 进行OCR识别(参数类型为字符串)
detectFromFile(path：string)：传入图片的 文件地址 进行OCR识别(参数类型为字符串)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
