### PR TITLE
test: 新增react-native-safe-modules的测试用例

### DIFF
--- a/react-native-safe-modules/SafeModuleDemo.tsx
+++ b/react-native-safe-modules/SafeModuleDemo.tsx
@@ -1,0 +1,10 @@
+import SafeModule from 'react-native-safe-modules';
+
+const myModule = SafeModule.create({
+  moduleName: 'MyNativemodule',
+  mock: {
+    someAPI: () => 'doSomething'
+  }
+})
+
+export default myModule

--- a/react-native-safe-modules/test/SafeModuleExample.tsx
+++ b/react-native-safe-modules/test/SafeModuleExample.tsx
@@ -1,0 +1,268 @@
+import { TestSuite, Tester, TestCase } from '@rnoh/testerino';
+import * as React from 'react';
+import SafeModule from 'react-native-safe-modules';
+import { View, Button } from 'react-native';
+
+/* 
+  注意：这个示例获取的是 reac-native-keep-awake 的 NativeModule，测试前需要安装 reac-native-keep-awake 这个库，
+        reac-native-keep-awake 源库的 NativeModule 名称为 KCKeepAwake
+        harmonyOS化过的的 NativeModule 名称为 KeepAwakeNativeModule，
+        如果要测试create、module接口
+          1. 获取 harmonyOS 的 NativeModule，请将参数 moduleName 改为 KeepAwakeNativeModule，
+          2. iOS/Android的参数 moduleName  名称为 KCKeepAwake
+*/
+
+const MyButton = SafeModule.component({
+  viewName: 'NonExistentViewName',
+  propOverrides: {
+    '1.0.0': (nativeProps: any, config: any, nativeModule: any) => {
+      return {
+        newProp: 'newValue',
+      };
+    },
+  },
+  componentOverrides: {
+    '1.0.0': (nativeComponent: any, nativeModule: any) => {
+      return class CustomComponent extends React.Component {
+        nativeComponent = nativeComponent
+        render() {
+          return <this.nativeComponent {...this.props} />;
+        }
+      };
+    },
+  },
+  mockComponent: Button,
+  mock: {
+    activate: () => 1,
+  },
+  getVersion: () => '1.0.0',
+});
+
+
+export default function SafeModuleExample() {
+  return (
+    <View>
+      <Tester>
+        <TestSuite name="SafeModule">
+          <TestCase
+            itShould="component接口 模拟组件 Button"
+            initialState={false}
+            assert={({expect, state}) => {
+              expect(state).to.be.true;
+            }}
+            arrange={({setState}) => (
+              <MyButton
+                title={'component接口 模拟按钮'}
+                onPress={() => {
+                  setState(true);
+                }}
+              >
+              </MyButton>
+            )}
+          >
+          </TestCase>
+          <TestCase
+            itShould="create接口 获取react-native-keep-awake的NativeModule"
+            fn={({expect}: any) => {
+              // iOS/Android中moduleName为 KCKeepAwake
+              const myModules = SafeModule.create({
+                moduleName: 'KeepAwakeNativeModule',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myModules.activate()).to.not.be.eql(1);
+            }}
+          />
+          <TestCase
+            itShould="create接口 获取react-native-keep-awake的NativeModule moduleName传递一个数组"
+            fn={({expect}: any) => {
+              // iOS/Android中moduleName为 KCKeepAwake
+              const myModules = SafeModule.create({
+                moduleName: ['KeepAwakeNativeModule', 'MyModule'],
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myModules.activate()).to.not.be.eql(1);
+            }}
+          />
+          <TestCase
+            itShould="create接口 自己模拟的NativeModule"
+            fn={({expect}: any) => {
+              const myKCKeepAwake = SafeModule.create({ 
+                moduleName: 'MyKCKeepAwake',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: () => (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myKCKeepAwake.activate()).to.eql(1);
+            }}
+          />
+           <TestCase
+            itShould="module接口 获取react-native-keep-awake的NativeModule"
+            fn={({expect}: any) => {
+              // iOS/Android中moduleName为 KCKeepAwake
+              const myModules = SafeModule.module({
+                moduleName: 'KeepAwakeNativeModule',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myModules.activate()).to.not.be.eql(1);
+            }}
+          />
+          <TestCase
+            itShould="module接口 获取react-native-keep-awake的NativeModule moduleName传递一个数组"
+            fn={({expect}: any) => {
+              // iOS/Android中moduleName为 KCKeepAwake
+              const myModules = SafeModule.module({
+                moduleName: ['KeepAwakeNativeModule', 'MyModule'],
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myModules.activate()).to.not.be.eql(1);
+            }}
+          />
+          <TestCase
+            itShould="module接口 自己模拟的NativeModule"
+            fn={({expect}: any) => {
+              const myKCKeepAwake = SafeModule.module({ 
+                moduleName: 'MyKCKeepAwake',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                getVersion: () => 1,
+                versionOverrides: {
+                  1: {
+                    oldactivate: () => (moduleKey: any, module: any) => ({moduleKey, module})
+                  },
+                },
+                isEventEmitter: true
+              })
+              expect(myKCKeepAwake.activate()).to.eql(1);
+            }}
+          />
+
+          <TestCase
+            itShould="create接口 获取react-native-keep-awake的NativeModule isEventEmitter为true creates an EventEmitter"
+            fn={({expect}: any) => {
+              const result = SafeModule.create({
+                moduleName: 'KeepAwakeNativeModule',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                isEventEmitter: true,
+              });
+              expect(result.emitter.addListener).to.be.a('function');
+              expect(result.emitter.removeAllListeners).to.be.a('function');
+            }}
+          />
+
+          <TestCase
+            itShould="create接口 自定义moduleName isEventEmitter为true creates an EventEmitter"
+            fn={({expect}: any) => {
+              const mock = {
+                foo: 1,
+              };
+              const result = SafeModule.create({
+                moduleName: 'UniqueModuleName',
+                mock,
+                isEventEmitter: true,
+              });
+              expect(result.addListener).to.be.a('function');
+              expect(result.removeListeners).to.be.a('function');
+              expect(result.emitter.addListener).to.be.a('function');
+              expect(result.emitter.removeAllListeners).to.be.a('function');
+            }}
+          />
+
+          <TestCase
+            itShould="module接口 获取react-native-keep-awake的NativeModule isEventEmitter为true creates an EventEmitter"
+            fn={({expect}: any) => {
+              const result = SafeModule.create({
+                moduleName: 'KeepAwakeNativeModule',
+                mock: {
+                  activate: () => 1,
+                  deactivate: () => 2,
+                  getConstans: () => 3
+                },
+                isEventEmitter: true,
+              });
+              expect(result.emitter.addListener).to.be.a('function');
+              expect(result.emitter.removeAllListeners).to.be.a('function');
+            }}
+          />
+
+          <TestCase
+            itShould="module接口 自定义moduleName isEventEmitter为true creates an EventEmitter"
+            fn={({expect}: any) => {
+              const mock = {
+                foo: 1,
+              };
+              const result = SafeModule.module({
+                moduleName: 'UniqueModuleName',
+                mock,
+                isEventEmitter: true,
+              });
+              expect(result.addListener).to.be.a('function');
+              expect(result.removeListeners).to.be.a('function');
+              expect(result.emitter.addListener).to.be.a('function');
+              expect(result.emitter.removeAllListeners).to.be.a('function');
+            }}
+          />
+        </TestSuite>
+      </Tester>
+    </View>
+  );
+}


### PR DESCRIPTION
# Summary

1. 新增react-native-safe-modules的测试用例
2. 一共提供了3个API：create、module、component
3. create、module作用是使用三方库的时候可以换一个写法；component接口在iOS和Android中的功能都不齐全，代码只能执行一部分，功能只有重命名组件

## Test Plan

![测试](https://github.com/user-attachments/assets/c4407806-6e44-4e46-937b-d705ee53d38d)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

