### PR TITLE
feat: 新增react-native-async-storage-async-storage示例代码及测试用例

### DIFF
--- a/react-native-async-storage-async-storage/Example/Async-storage-hook.tsx
+++ b/react-native-async-storage-async-storage/Example/Async-storage-hook.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { useAsyncStorage } from "@react-native-async-storage/async-storage";
+
+export default function App() {
+  const [value, setValue] = useState("value");
+  const { getItem, setItem } = useAsyncStorage("@storage_key");
+
+  const readItemFromStorage = async () => {
+    const item = await getItem();
+    setValue(item);
+  };
+
+  const writeItemToStorage = async (newValue) => {
+    await setItem(newValue);
+    setValue(newValue);
+  };
+
+  useEffect(() => {
+    readItemFromStorage();
+  }, []);
+
+  return (
+    <View style={{ margin: 40 }}>
+      <Text>Current value: {value}</Text>
+      <TouchableOpacity
+        onPress={() =>
+          writeItemToStorage(Math.random().toString(36).substr(2, 5))
+        }
+      >
+        <Text>Update value</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/react-native-async-storage-async-storage/Example/Async-storage.tsx
+++ b/react-native-async-storage-async-storage/Example/Async-storage.tsx
@@ -1,0 +1,30 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Button } from "react-native";
+
+// Storing data
+const storeData = async (value) => {
+  try {
+    await AsyncStorage.setItem("my-key", value);
+  } catch (e) {
+    // saving error
+  }
+};
+
+// Reading data
+const getData = async () => {
+  try {
+    const value = await AsyncStorage.getItem("my-key");
+    if (value !== null) {
+      // value previously stored
+    }
+  } catch (e) {
+    // error reading value
+  }
+};
+
+export default function AsyncStorageDemo(){
+    return <>
+    <Button title="setItem" onPress={storeData} />
+    <Button title="getItem" onPress={getData} />
+    </>
+}

--- a/react-native-async-storage-async-storage/TesterDemo/AsyncStorage-Hook.tsx
+++ b/react-native-async-storage-async-storage/TesterDemo/AsyncStorage-Hook.tsx
@@ -1,0 +1,125 @@
+import React, {useEffect, useState} from 'react';
+
+import {View, ScrollView, Text} from 'react-native';
+import {Tester, TestSuite, TestCase} from '@rnoh/testerino';
+import {Button} from '../components';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {useAsyncStorage} from '@react-native-async-storage/async-storage';
+const Meun = [
+  {
+    key: 'async_storage_1',
+    itShould: 'Sets a string(hello) value for given key(test)',
+    label: 'useAsyncStorage_setItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      const {setItem} = useAsyncStorage('test');
+      setItem('hello', error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_2',
+    itShould: 'Gets a string value for given key(test)',
+    label: 'useAsyncStorage_getItem',
+    onPress: (
+      setState: (arg0: boolean) => void,
+    ) => {
+      const {getItem} = useAsyncStorage('test');
+      getItem((e, r) => {
+        setState(r === 'hello');
+      });
+    },
+  },
+  {
+    key: 'async_storage_3',
+    itShould:
+      'Merges an existing value({name:lili,age:20}) stored under key(test_mergeItem), with new value({name:lili,age:21,sex:women}), assuming both values are stringified JSON',
+    label: 'useAsyncStorage_mergeItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      const {setItem, mergeItem} = useAsyncStorage('test_mergeItem');
+      setItem(JSON.stringify({name: 'lili', age: 20}));
+      mergeItem(
+        JSON.stringify({name: 'lili', age: 21, sex: 'women'}),
+        error => {
+          setState(!error);
+        },
+      );
+    },
+  },
+  {
+    key: 'async_storage_4',
+    itShould: 'Removes item for a key(test_mergeItem)',
+    label: 'useAsyncStorage_removeItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      const {removeItem} = useAsyncStorage('test_mergeItem');
+      removeItem(error => {
+        setState(!error);
+      });
+    },
+  },
+ 
+];
+export const ProgressViewDemo = () => {
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('');
+  const [current,setCurrent]=useState(0)
+  const handDisplay = async () => {
+    setKey("")
+    const r = await AsyncStorage.getAllKeys();
+    setKey(r.map(item => `${item}`).join(','));
+  };
+  const display = () => {
+    return (
+      <>
+        <Button label={`当前key: ${key}`} onPress={() => {}}></Button>
+        <Button label={`当前value: ${value}`} onPress={() => {}}></Button>
+
+      </>
+    );
+  };
+  useEffect(() => {
+    !key && handDisplay();
+    AsyncStorage.getAllKeys(async (e, r) => {
+      let list = [];
+      for (const item of r) {
+        const result = await AsyncStorage.getItem(item);
+        list.push(result);
+      }
+
+      setValue(list.join(','));
+    });
+  }, [key]);
+  return (
+    <Tester>
+      <ScrollView>
+        <TestSuite name="@react-native-async-storage/async-storage">
+          {Meun.map((item,index) => (
+            <TestCase
+              key={item.key}
+              itShould={item.itShould}
+              tags={['C_API']}
+              initialState={false}
+              arrange={({setState}) => {
+                return (
+                  <View style={{flex: 1}}>
+                    {current===index&&display()}
+                    <Button
+                      label={item.label}
+                      onPress={() => {
+                        setCurrent(index)
+                        item.onPress(setState);
+                        handDisplay();
+                      }}></Button>
+                  </View>
+                );
+              }}
+              assert={async ({expect, state}) => {
+                expect(state).to.be.true;
+              }}
+            />
+          ))}
+        </TestSuite>
+      </ScrollView>
+    </Tester>
+  );
+};

--- a/react-native-async-storage-async-storage/TesterDemo/AsyncStorage.tsx
+++ b/react-native-async-storage-async-storage/TesterDemo/AsyncStorage.tsx
@@ -1,0 +1,228 @@
+import React, {useEffect, useState} from 'react';
+
+import {View, ScrollView, Text} from 'react-native';
+import {Tester, TestSuite, TestCase} from '@rnoh/testerino';
+import {Button} from '../components';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const Meun = [
+  {
+    key: 'async_storage_1',
+    itShould: 'Sets a string(hello) value for given key(test)',
+    label: 'useAsyncStorage_setItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      AsyncStorage.setItem('test', 'hello', error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_2',
+    itShould: 'Gets a string value for given key(test)',
+    label: 'useAsyncStorage_getItem',
+    onPress: (
+      setState: (arg0: boolean) => void,
+    ) => {
+      AsyncStorage.getItem('test', (e, r) => {
+        setState(r === 'hello');
+      });
+    },
+  },
+  {
+    key: 'async_storage_3',
+    itShould:
+      'Merges an existing value({name:lili,age:20}) stored under key(test_mergeItem), with new value({name:lili,age:21,sex:women}), assuming both values are stringified JSON',
+    label: 'useAsyncStorage_mergeItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      AsyncStorage.setItem(
+        'test_mergeItem',
+        JSON.stringify({name: 'lili', age: 20}),
+      );
+      AsyncStorage.mergeItem(
+        'test_mergeItem',
+        JSON.stringify({name: 'lili', age: 21, sex: 'women'}),
+        error => {
+          setState(!error);
+        },
+      );
+    },
+  },
+  {
+    key: 'async_storage_4',
+    itShould: 'Removes item for a key(test_mergeItem)',
+    label: 'useAsyncStorage_removeItem',
+    onPress: (setState: (arg0: boolean) => void) => {
+      AsyncStorage.removeItem('test_mergeItem', error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_5',
+    itShould: 'Returns all keys known to your App',
+    label: 'useAsyncStorage_getAllKeys',
+    onPress: (setState: (arg0: boolean) => void) => {
+      AsyncStorage.getAllKeys(error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_6',
+    itShould: 'Stores multiple key-value pairs in a batch',
+    label: 'useAsyncStorage_multiSet',
+    onPress: (setState: (arg0: boolean) => void) => {
+      const firstPair = ['@MyApp_user', 'value_1'];
+      const secondPair = ['@MyApp_key', 'value_2'];
+      AsyncStorage.multiSet([firstPair, secondPair], error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_7',
+    itShould:
+      'Fetches multiple key-value pairs for given array of keys in a batch',
+    label: 'useAsyncStorage_multiGet',
+    onPress: (
+      setState: (arg0: boolean) => void,
+    ) => {
+      AsyncStorage.multiGet(['@MyApp_user', '@MyApp_key'], (error, r) => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_8',
+    itShould: 'Multiple merging of existing and new values in a batch',
+    label: 'useAsyncStorage_multiMerge',
+    onPress: async (setState: (arg0: boolean) => void) => {
+      const USER_1 = {
+        name: 'Tom',
+        age: 30,
+        traits: {hair: 'brown'},
+      };
+
+      const USER_1_DELTA = {
+        age: 31,
+        traits: {eyes: 'blue'},
+      };
+
+      const USER_2 = {
+        name: 'Sarah',
+        age: 25,
+        traits: {hair: 'black'},
+      };
+
+      const USER_2_DELTA = {
+        age: 26,
+        traits: {hair: 'green'},
+      };
+
+      const multiSet = [
+        ['@MyApp_USER_1', JSON.stringify(USER_1)],
+        ['@MyApp_USER_2', JSON.stringify(USER_2)],
+      ];
+
+      const multiMerge = [
+        ['@MyApp_USER_1', JSON.stringify(USER_1_DELTA)],
+        ['@MyApp_USER_2', JSON.stringify(USER_2_DELTA)],
+      ];
+      try {
+        await AsyncStorage.multiSet(multiSet);
+        await AsyncStorage.multiMerge(multiMerge);
+        const currentlyMerged = await AsyncStorage.multiGet([
+          '@MyApp_USER_1',
+          '@MyApp_USER_2',
+        ]);
+        setState(!!currentlyMerged);
+      } catch (e) {
+        // error
+      }
+    },
+  },
+  {
+    key: 'async_storage_9',
+    itShould: 'Sets a string value for given key',
+    label: 'useAsyncStorage_multiRemove',
+    onPress: (setState: (arg0: boolean) => void) => {
+      const keys = ['@MyApp_USER_1', '@MyApp_USER_2'];
+      AsyncStorage.multiRemove(keys, error => {
+        setState(!error);
+      });
+    },
+  },
+  {
+    key: 'async_storage_10',
+    itShould: 'Removes whole AsyncStorage data, for all clients, libraries',
+    label: 'useAsyncStorage_clear',
+    onPress: (setState: (arg0: boolean) => void) => {
+      AsyncStorage.clear(error => {
+        setState(!error);
+      });
+    },
+  },
+];
+export const ProgressViewDemo = () => {
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('');
+  const [current,setCurrent]=useState(0)
+  const handDisplay = async () => {
+    const r = await AsyncStorage.getAllKeys();
+    setKey(r.map(item => `${item}`).join(','));
+  };
+  const display = () => {
+    return (
+      <>
+        <Button label={`当前key: ${key}`} onPress={() => {}}></Button>
+        <Button label={`当前value: ${value}`} onPress={() => {}}></Button>
+
+      </>
+    );
+  };
+  useEffect(() => {
+    !key && handDisplay();
+    AsyncStorage.getAllKeys(async (e, r) => {
+      let list = [];
+      for (const item of r) {
+        const result = await AsyncStorage.getItem(item);
+        list.push(result);
+      }
+
+      setValue(list.join(','));
+    });
+  }, [key]);
+  return (
+    <Tester>
+      <ScrollView>
+        <TestSuite name="@react-native-async-storage/async-storage">
+          {Meun.map((item,index) => (
+            <TestCase
+              key={item.key}
+              itShould={item.itShould}
+              tags={['C_API']}
+              initialState={false}
+              arrange={({setState}) => {
+                return (
+                  <View style={{flex: 1}}>
+                     {current===index&&display()}
+                    <Button
+                      label={item.label}
+                      onPress={() => {
+                        setCurrent(index)
+                        item.onPress(setState);
+                        handDisplay();
+                      }}></Button>
+                  </View>
+                );
+              }}
+              assert={async ({expect, state}) => {
+                expect(state).to.be.true;
+              }}
+            />
+          ))}
+        </TestSuite>
+      </ScrollView>
+    </Tester>
+  );
+};


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增react-native-audio-recorder-player示例代码
- 新增测试用例覆盖全量静态方法,及hook用法
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:\Users\lwx1346351\AppData\Local\Temp\msohtmlclip1\01\clip.htm">
<link rel=File-List
href="file:///C:\Users\lwx1346351\AppData\Local\Temp\msohtmlclip1\01\clip_filelist.xml">

</head>

<body link=blue vlink=purple>


getItem(key:   string, [callback]: ?(error: ?Error, result: ?string) => void): Promise | 根据给定的key获取对应的string值
-- | --
setItem(key: string, value: string, [callback]: ?(error: ?Error)   => void): Promise | 设定给定key的string值
mergeItem(key: string, value: string, [callback]: ?(error:   ?Error) => void): Promise | 将存储在key下的现有值与新值合并
removeItem(key: string, [callback]: ?(error: ?Error) =>   void): Promise | 将给定key的值删除
getAllKeys([callback]: ?(error: ?Error, keys:   ?Array<string>) => void): Promise | 返回所有已知的key
multiGet(keys: Array<string>, [callback]: ?(errors:   ?Array<Error>, result: ?Array<Array<string>>) => void):   Promise | 批量获取给定key数组的多个键值对
multiSet(keyValuePairs: Array<Array<string>>,   [callback]: ?(errors: ?Array<Error>) => void): Promise | 批量存储多个键值对
multiMerge(keyValuePairs:   Array<Array<string>>, [callback]: ?(errors: ?Array<Error>)   => void): Promise | 批量合并现有值和新值
multiRemove(keys:   Array<string>, [callback]: ?(errors: ?Array<Error>) => void) | 批量删除给定key数组的多个键值对
clear([callback]:   ?(error: ?Error) => void): Promise | 移除整个AsyncStorage数据
useAsyncStorage | 自定义hook，暴露所有方法



</body>

</html>


<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)