### PR TITLE
feat: 新增react-native-audio-recorder-player测试用例及示例代码

### DIFF
--- a/react-native-audio-recorder-player/AudioRecordPlayerExample/Audio-recorder-player.tsx
+++ b/react-native-audio-recorder-player/AudioRecordPlayerExample/Audio-recorder-player.tsx
@@ -1,0 +1,370 @@
+import AudioRecorderPlayer, {
+    AVEncoderAudioQualityIOSType,
+    AVEncodingOption,
+    AudioEncoderAndroidType,
+    AudioSourceAndroidType,
+    OutputFormatAndroidType,
+  } from 'react-native-audio-recorder-player';
+  import type {
+    AudioSet,
+    PlayBackType,
+    RecordBackType,
+  } from 'react-native-audio-recorder-player';
+  import {
+    Dimensions,
+    Platform,
+    SafeAreaView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+  } from 'react-native';
+  import React, {Component} from 'react';
+  
+  import Button from './Button';
+  import type {ReactElement} from 'react';
+  
+  const styles: any = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: '#455A64',
+      flexDirection: 'column',
+      alignItems: 'center',
+      height:Dimensions.get('screen').height
+    },
+    titleTxt: {
+      marginTop: 100,
+      color: 'white',
+      fontSize: 28,
+    },
+    viewRecorder: {
+      marginTop: 40,
+      width: '100%',
+      alignItems: 'center',
+    },
+    recordBtnWrapper: {
+      flexDirection: 'row',
+    },
+    viewPlayer: {
+      marginTop: 60,
+      alignSelf: 'stretch',
+      alignItems: 'center',
+    },
+    viewBarWrapper: {
+      marginTop: 28,
+      marginHorizontal: 28,
+      alignSelf: 'stretch',
+    },
+    viewBar: {
+      backgroundColor: '#ccc',
+      height: 4,
+      alignSelf: 'stretch',
+    },
+    viewBarPlay: {
+      backgroundColor: 'white',
+      height: 4,
+      width: 0,
+    },
+    playStatusTxt: {
+      marginTop: 8,
+      color: '#ccc',
+    },
+    playBtnWrapper: {
+      flexDirection: 'row',
+      marginTop: 40,
+    },
+    btn: {
+      borderColor: 'white',
+      borderWidth: 1,
+    },
+    txt: {
+      color: 'white',
+      fontSize: 14,
+      marginHorizontal: 8,
+      marginVertical: 4,
+    },
+    txtRecordCounter: {
+      marginTop: 32,
+      color: 'white',
+      fontSize: 20,
+      textAlignVertical: 'center',
+      fontWeight: '200',
+      fontFamily: 'Helvetica Neue',
+      letterSpacing: 3,
+      width:300
+    },
+    txtCounter: {
+      marginTop: 12,
+      color: 'white',
+      fontSize: 20,
+      textAlignVertical: 'center',
+      fontWeight: '200',
+      fontFamily: 'Helvetica Neue',
+      letterSpacing: 3,
+      width:300
+    },
+  });
+  
+  interface State {
+    isLoggingIn: boolean;
+    recordSecs: number;
+    recordTime: string;
+    currentPositionSec: number;
+    currentDurationSec: number;
+    playTime: string;
+    duration: string;
+  }
+  
+  const screenWidth = Dimensions.get('screen').width;
+  
+   class Page extends Component<any, State> {
+    private audioRecorderPlayer
+    
+    constructor(props: any) {
+      super(props);
+      this.state = {
+        isLoggingIn: false,
+        recordSecs: 0,
+        recordTime: '00:00:00',
+        currentPositionSec: 0,
+        currentDurationSec: 0,
+        playTime: '00:00:00',
+        duration: '00:00:00',
+      };
+  
+      this.audioRecorderPlayer = new AudioRecorderPlayer()
+      this.audioRecorderPlayer.setSubscriptionDuration(0.5); // optional. Default is 0.5
+    }
+  
+    public render(): ReactElement {
+      let playWidth =
+        (this.state.currentPositionSec / this.state.currentDurationSec) *
+        (screenWidth - 56);
+  
+      if (!playWidth) {
+        playWidth = 0;
+      }
+  
+      return (
+        <SafeAreaView style={styles.container}>
+          <Text style={styles.titleTxt}>Audio Recorder Player</Text>
+          <Text style={styles.txtRecordCounter}>{this.state.recordTime}</Text>
+          <View style={styles.viewRecorder}>
+            <View style={styles.recordBtnWrapper}>
+              <Button
+                style={styles.btn}
+                onPress={this.onStartRecord}
+                textStyle={styles.txt}>
+                startRecord
+              </Button>
+              <Button
+                style={[
+                  styles.btn,
+                  {
+                    marginLeft: 12,
+                  },
+                ]}
+                onPress={this.onPauseRecord}
+                textStyle={styles.txt}>
+                Pause
+              </Button>
+              <Button
+                style={[
+                  styles.btn,
+                  {
+                    marginLeft: 12,
+                  },
+                ]}
+                onPress={this.onResumeRecord}
+                textStyle={styles.txt}>
+                Resume
+              </Button>
+              <Button
+                style={[styles.btn, {marginLeft: 12}]}
+                onPress={this.onStopRecord}
+                textStyle={styles.txt}>
+                Stop
+              </Button>
+            </View>
+          </View>
+          <View style={styles.viewPlayer}>
+            <TouchableOpacity
+              style={styles.viewBarWrapper}
+              onPress={this.onStatusPress}>
+              <View style={styles.viewBar}>
+                <View style={[styles.viewBarPlay, {width: playWidth}]} />
+              </View>
+            </TouchableOpacity>
+            <Text style={styles.txtCounter}>
+              {this.state.playTime} / {this.state.duration}
+            </Text>
+            <View style={styles.playBtnWrapper}>
+              <Button
+                style={styles.btn}
+                onPress={this.onStartPlay}
+                textStyle={styles.txt}>
+                Play
+              </Button>
+              <Button
+                style={[
+                  styles.btn,
+                  {
+                    marginLeft: 12,
+                  },
+                ]}
+                onPress={this.onPausePlay}
+                textStyle={styles.txt}>
+                Pause
+              </Button>
+              <Button
+                style={[
+                  styles.btn,
+                  {
+                    marginLeft: 12,
+                  },
+                ]}
+                onPress={this.onResumePlay}
+                textStyle={styles.txt}>
+                Resume
+              </Button>
+              <Button
+                style={[
+                  styles.btn,
+                  {
+                    marginLeft: 12,
+                  },
+                ]}
+                onPress={this.onStopPlay}
+                textStyle={styles.txt}>
+                Stop
+              </Button>
+            </View>
+          </View>
+        </SafeAreaView>
+      );
+    }
+  
+    private onStatusPress = (e: any): void => {
+      const touchX = e.nativeEvent.locationX;
+      console.log(`touchX: ${touchX}`);
+  
+      const playWidth =
+        (this.state.currentPositionSec / this.state.currentDurationSec) *
+        (screenWidth - 56);
+      console.log(`currentPlayWidth: ${playWidth}`);
+  
+      const currentPosition = Math.round(this.state.currentPositionSec);
+  
+      if (playWidth && playWidth < touchX) {
+        const addSecs = Math.round(currentPosition + 1000);
+        this.audioRecorderPlayer.seekToPlayer(addSecs);
+        console.log(`addSecs: ${addSecs}`);
+      } else {
+        const subSecs = Math.round(currentPosition - 1000);
+        this.audioRecorderPlayer.seekToPlayer(subSecs);
+        console.log(`subSecs: ${subSecs}`);
+      }
+    };
+  
+    private onStartRecord = async (): Promise<void> => {
+  
+      const audioSet: AudioSet = {
+        AudioEncoderAndroid: AudioEncoderAndroidType.AAC,
+        AudioSourceAndroid: AudioSourceAndroidType.MIC,
+        AVEncoderAudioQualityKeyIOS: AVEncoderAudioQualityIOSType.high,
+        AVNumberOfChannelsKeyIOS: 2,
+        AVFormatIDKeyIOS: AVEncodingOption.aac,
+        OutputFormatAndroid: OutputFormatAndroidType.AAC_ADTS,
+      };
+  
+      console.log('audioSet', audioSet);
+  
+      const uri = await this.audioRecorderPlayer.startRecorder(
+        this.path,
+        audioSet,
+      );
+  
+      this.audioRecorderPlayer.addRecordBackListener((e: RecordBackType) => {
+        console.log('record-back', e);
+        this.setState({
+          recordSecs: e.currentPosition,
+          recordTime: this.audioRecorderPlayer.mmssss(
+            Math.floor(e.currentPosition),
+          ),
+        });
+      });
+      
+      console.log(`uri: ${uri}`);
+    };
+  
+    private onPauseRecord = async (): Promise<void> => {
+      try {
+        const r = await this.audioRecorderPlayer.pauseRecorder();
+        console.log(r);
+      } catch (err) {
+        console.log('pauseRecord', err);
+      }
+    };
+  
+    private onResumeRecord = async (): Promise<void> => {
+      await this.audioRecorderPlayer.resumeRecorder();
+    };
+  
+    private onStopRecord = async (): Promise<void> => {
+      const result = await this.audioRecorderPlayer.stopRecorder();
+      this.audioRecorderPlayer.removeRecordBackListener();
+      this.setState({
+        recordSecs: 0,
+      });
+      console.log(result,'>>>>>>>stopRecorder');
+    };
+  
+    private onStartPlay = async (): Promise<void> => {
+      console.log('onStartPlay');
+  
+      try {
+        
+        
+          const msg = await this.audioRecorderPlayer.startPlayer();
+          const volume = await this.audioRecorderPlayer.setVolume(1);
+          this.audioRecorderPlayer.addPlayBackListener((e: PlayBackType) => {
+            console.log('playBackListener', e);
+            this.setState({
+              currentPositionSec: e.currentPosition,
+              currentDurationSec: e.duration,
+              playTime: this.audioRecorderPlayer.mmss(
+                Math.floor(e.currentPosition),
+              ),
+              duration: this.audioRecorderPlayer.mmss(Math.floor(e.duration)),
+            });
+          });
+         
+        //? Default path
+        // const msg = await this.audioRecorderPlayer.startPlayer();
+        // console.log(`startPlayer: ${JSON.stringify(msg)} volume ${volume},r ${r}`);
+          
+       
+       
+
+      } catch (err) {
+        console.log('startPlayer error', err);
+      }
+    };
+  
+    private onPausePlay = async (): Promise<void> => {
+      await this.audioRecorderPlayer.pausePlayer();
+    };
+  
+    private onResumePlay = async (): Promise<void> => {
+      await this.audioRecorderPlayer.resumePlayer();
+    };
+  
+    private onStopPlay = async (): Promise<void> => {
+      console.log('onStopPlay');
+      this.audioRecorderPlayer.stopPlayer();
+      this.audioRecorderPlayer.removePlayBackListener();
+    };
+  }
+  
+  export default Page;
+  

--- a/react-native-audio-recorder-player/AudioRecordPlayerExample/Button.tsx
+++ b/react-native-audio-recorder-player/AudioRecordPlayerExample/Button.tsx
@@ -1,0 +1,117 @@
+import {
+  ActivityIndicator,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type {ReactElement, ReactNode} from 'react';
+
+import {Component} from 'react';
+
+// import NativeButton from 'apsl-react-native-button';
+
+const styles: any = StyleSheet.create({
+  btn: {
+    backgroundColor: 'transparent',
+    alignSelf: 'center',
+    borderRadius: 4,
+    borderWidth: 2,
+    width: 320,
+    height: 52,
+    borderColor: 'white',
+
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnDisabled: {
+    backgroundColor: 'rgb(243,243,243)',
+    alignSelf: 'center',
+    borderRadius: 4,
+    borderWidth: 2,
+    width: 320,
+    height: 52,
+    borderColor: '#333',
+
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  txt: {
+    fontSize: 14,
+    color: 'white',
+  },
+  imgLeft: {
+    width: 24,
+    height: 24,
+    position: 'absolute',
+    left: 16,
+  },
+});
+
+interface ItemProps {
+  children?: ReactNode;
+  isLoading?: boolean;
+  isDisabled?: boolean;
+  onPress?: () => void;
+  style?: any;
+  disabledStyle?: any;
+  textStyle?: any;
+  imgLeftSrc?: any;
+  imgLeftStyle?: any;
+  indicatorColor?: string;
+  activeOpacity?: number;
+}
+
+class Button extends Component<ItemProps, any> {
+  private static defaultProps: Partial<ItemProps> = {
+    isLoading: false,
+    isDisabled: false,
+    style: styles.btn,
+    textStyle: styles.txt,
+    imgLeftStyle: styles.imgLeft,
+    indicatorColor: 'white',
+    activeOpacity: 0.5,
+  };
+
+  constructor(props: ItemProps) {
+    super(props);
+    this.state = {};
+  }
+
+  public render(): ReactElement {
+    if (this.props.isDisabled) {
+      return (
+        <View style={this.props.disabledStyle}>
+          <Text style={this.props.textStyle}>{this.props.children}</Text>
+        </View>
+      );
+    }
+
+    if (this.props.isLoading) {
+      return (
+        <View style={this.props.style}>
+          <ActivityIndicator size="small" color={this.props.indicatorColor} />
+        </View>
+      );
+    }
+
+    return (
+      <TouchableOpacity
+        activeOpacity={this.props.activeOpacity}
+        onPress={this.props.onPress}>
+        <View style={this.props.style}>
+          {this.props.imgLeftSrc ? (
+            <Image
+              style={this.props.imgLeftStyle}
+              source={this.props.imgLeftSrc}
+            />
+          ) : null}
+          <Text style={this.props.textStyle}>{this.props.children}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+export default Button;

--- a/react-native-audio-recorder-player/test/AudioRecordPlayerExample.tsx
+++ b/react-native-audio-recorder-player/test/AudioRecordPlayerExample.tsx
@@ -1,0 +1,207 @@
+import React, {useEffect, useState} from 'react';
+
+import {View, ScrollView, Text} from 'react-native';
+import {Tester, TestSuite, TestCase} from '@rnoh/testerino';
+import {Button} from './Button';
+import AudioRecorderPlayer from 'react-native-audio-recorder-player';
+
+const AudioRecorder=new AudioRecorderPlayer()
+
+
+ export const ProgressViewDemo = () => {
+  const [recorderTime,setRecorderTime]=useState('00:00:00')
+  const [playTime,setPlayTime]=useState('00:00:00')
+  const [duration,setDuration]=useState('00:00:00')
+  const [value,setValue]=useState('')
+  const Meun = [
+    {
+      key: 'recorder-player_1',
+      itShould: 'Start recording',
+      label: 'startRecord',
+      onPress:async (setState: (arg0: boolean) => void) => {
+        const url=await  AudioRecorder.startRecorder()
+        setValue(url)
+          AudioRecorder.addRecordBackListener((r)=>{
+              console.log(r)
+              setState(!!r.isRecording)
+              setRecorderTime(AudioRecorder.mmssss(r.currentPosition))
+          })
+      },
+    },
+    {
+      key: 'recorder-player_2',
+      itShould: 'Pause recording',
+      label: 'Pause',
+      onPress: async(setState: (arg0: boolean) => void) => {
+       const r=await   AudioRecorder.pauseRecorder()
+       setValue(r)
+       setState(!!r)
+       
+      },
+    },
+    {
+      key: 'recorder-player_3',
+      itShould: 'Resume recording' ,
+      label: 'Resume',
+      onPress:async (setState: (arg0: boolean) => void) => {
+         const r=await AudioRecorder.resumeRecorder()
+         setValue(r)
+         setState(!!r)
+       
+      },
+    },
+    {
+      key: 'recorder-player_4',
+      itShould: 'Stop recording',
+      label: 'Stop',
+      onPress: async(setState: (arg0: boolean) => void) => {
+        const url=await  AudioRecorder.stopRecorder()
+        setValue(url)
+        setState(!!url)
+      },
+    },
+    {
+      key: 'recorder-player_5',
+      itShould: 'Playing url' ,
+      label: 'Play（url）',
+      onPress: (setState: (arg0: boolean) => void) => {
+          AudioRecorder.startPlayer('https://er-sycdn.kuwo.cn/5b858d0bd5f89c809d37cd56f7b6d738/66aa16aa/resource/30106/trackmedia/M800001ASMC447Mslm.mp3')
+          AudioRecorder.addPlayBackListener((r)=>{
+            console.log(r)
+              setState(!!r.currentPosition)
+              setPlayTime(AudioRecorder.mmssss(r.currentPosition))
+              setDuration(AudioRecorder.mmssss(r.duration))
+          })
+       
+      },
+    }, {
+      key: 'recorder-player_6',
+      itShould: 'Playing',
+      label: 'Play',
+      onPress: async(setState: (arg0: boolean) => void) => {
+         const r= await AudioRecorder.startPlayer()
+         setValue(r)
+          AudioRecorder.addPlayBackListener((r)=>{
+            console.log(r)
+            setState(!!r.currentPosition)
+            setPlayTime(AudioRecorder.mmssss(r.currentPosition))
+            setDuration(AudioRecorder.mmssss(r.duration))
+          })
+       
+      },
+    },
+    {
+      key: 'recorder-player_7',
+      itShould: 'Pause playing' ,
+      label: 'Pause',
+      onPress:async (setState: (arg0: boolean) => void) => {
+        const r=await  AudioRecorder.pausePlayer()
+       setValue(r)
+       setState(!!r)
+      },
+    }, {
+      key: 'recorder-player_8',
+      itShould: 'Resume playing',
+      label: 'Resume',
+      onPress: async(setState: (arg0: boolean) => void) => {
+        const r=await  AudioRecorder.resumePlayer()
+        setValue(r)
+       setState(!!r)
+       
+      },
+    },
+    {
+      key: 'recorder-player_9',
+      itShould: 'Stop playing' ,
+      label: 'Stop',
+      onPress:async (setState: (arg0: boolean) => void) => {
+        const r=await AudioRecorder.stopPlayer()
+          setValue(r)
+          setState(!!r)
+      },
+    }, {
+      key: 'recorder-player_10',
+      itShould: 'setSubscriptionDuration',
+      label: 'setSubscriptionDuration 3s',
+      onPress:async (setState: (arg0: boolean) => void) => {
+        const r=await AudioRecorder.setSubscriptionDuration(3)
+        setState(!!r)
+         setValue(r)
+      },
+    },
+    {
+      key: 'recorder-player_11',
+      itShould: 'setVolume' ,
+      label: 'setVolume to 0.8',
+      onPress:async(setState: (arg0: boolean) => void) => {
+        const r=await AudioRecorder.setVolume(0.8)
+        setState(!!r)
+        setValue(r)
+      },
+    }, {
+      key: 'recorder-player_12',
+      itShould: 'setVolume -',
+      label: 'setVolume to 0.4',
+      onPress: async(setState: (arg0: boolean) => void) => {
+        const r=await AudioRecorder.setVolume(0.4)
+        setState(!!r)
+        setValue(r)
+      },
+    },
+    {
+      key: 'recorder-player_13',
+      itShould: 'seekToPlayer to 1s' ,
+      label: 'seekToPlayer to 1s',
+      onPress: async(setState: (arg0: boolean) => void) => {
+        const r=await AudioRecorder.seekToPlayer(1000)
+        setState(!!r)
+        setValue(r)
+      },
+    },
+    {
+      key: 'recorder-player_14',
+      itShould: 'seekToPlayer to 10s' ,
+      label: 'seekToPlayer to 10s',
+      onPress: async(setState: (arg0: boolean) => void) => {
+        const r=await  AudioRecorder.seekToPlayer(10000)
+          setState(!!r)
+        setValue(r)
+       
+      },
+    },
+   
+  ];
+  return (
+    <Tester>
+      <ScrollView>
+        <TestSuite name="@react-native-audio-recorder-player">
+          <View style={{marginTop:20,flexDirection:'row'}}><Text style={{color:'#fff'}}>Recorder Time :</Text><Text style={{color:'#fff'}}>{recorderTime}</Text></View>
+          <View style={{marginTop:20,flexDirection:'row'}}><Text style={{color:'#fff'}}>Player Time :</Text><Text style={{color:'#fff'}}>{playTime}/{duration}</Text></View>
+          <View style={{marginTop:20,flexDirection:'row',marginBottom:20}}><Text style={{color:'#fff'}}>return Value:</Text><Text style={{color:'#fff'}}>{value}</Text></View>
+          {Meun.map(item => (
+            <TestCase
+              key={item.key}
+              itShould={item.itShould}
+              tags={['C_API']}
+              initialState={false}
+              arrange={({setState}) => {
+                return (
+                  <View style={{flex: 1}}>
+                    <Button
+                      label={item.label}
+                      onPress={() => {
+                        item.onPress(setState);
+                      }}></Button>
+                  </View>
+                );
+              }}
+              assert={async ({expect, state}) => {
+                expect(state).to.be.true;
+              }}
+            />
+          ))}
+        </TestSuite>
+      </ScrollView>
+    </Tester>
+  );
+};

--- a/react-native-audio-recorder-player/test/Button.tsx
+++ b/react-native-audio-recorder-player/test/Button.tsx
@@ -1,0 +1,21 @@
+import {Text, TouchableHighlight} from 'react-native';
+import {PALETTE} from './palette';
+
+export function Button({label, onPress}: {onPress: () => void; label: string}) {
+  return (
+    <TouchableHighlight
+      underlayColor={PALETTE.REACT_CYAN_DARK}
+      style={{
+        paddingVertical: 6,
+        paddingHorizontal: 12,
+        backgroundColor: PALETTE.REACT_CYAN_LIGHT,
+        borderWidth: 2,
+        borderColor: PALETTE.REACT_CYAN_DARK,
+      }}
+      onPress={onPress}>
+      <Text style={{color: 'black', fontWeight: 'bold', fontSize: 12}}>
+        {label}
+      </Text>
+    </TouchableHighlight>
+  );
+}

--- a/react-native-audio-recorder-player/test/palette.ts
+++ b/react-native-audio-recorder-player/test/palette.ts
@@ -1,0 +1,4 @@
+export const PALETTE = {
+  REACT_CYAN_LIGHT: 'hsl(193, 95%, 68%)',
+  REACT_CYAN_DARK: 'hsl(193, 95%, 30%)',
+};


### PR DESCRIPTION


# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个功能是什么？（如果适用）
- 音频录制与播放参照下列功能方法

<body link=blue vlink=purple>


mmssss(milliseconds:number   ):string | 将毫秒数转换为minute:second:milliseconds字符串
-- | --
mmss(milliseconds:number ):string | 将毫秒数转换为minute:second字符串
setSubscriptionDuration(sec: number): Promise<string> | 设置录音机或播放器时的默认回调时间。默认为500ms
addRecordBackListener(callBack:function):void | 录音开始时开始回调将收到currentPosition，currentMetering（如果在   startRecorder 中配置）
removeRecordBackListener(callBack:function):void | 删除   recordBack 监听器
addPlayBackListener(callBack:function):void | 获取原生模块的回调。将收到duration，currentPosition
removePlayBackListener(callBack:function):void | 移除播放监听器
startRecorder(uri?:string,AudioSet?:AudioSet):   Promise<void> | 开始录音。不传递   uri 将会将音频保存在默认位置。
pauseRecorder():   Promise<string> | 暂停录音。
resumeRecorder():   Promise<string> | 恢复录音。
stopRecorder():   Promise<string> | 停止录制。
startPlayer(   uri?:string,httpHeaders?:Record<string, string>): Promise<string> | 开始播放。不传递参数将在默认位置播放音频。
stopPlayer():   Promise<string> | 停止播放。
pausePlayer():   Promise<string> | 暂停播放。
seekToPlayer(milliseconds:number):   Promise<string> | 设置进度。
setVolume(value:float):   Promise<string> | 设置音频播放器的音量（默认1.0，范围：0.0~1.0）。



</body>

</html>


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
