### PR TITLE
test: 新增react-native-user-agent测试demo和测试用例

### DIFF
--- a/react-native-user-agent/demo/UserAgentDemo.tsx
+++ b/react-native-user-agent/demo/UserAgentDemo.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+import { SafeAreaView, Text, StyleSheet } from 'react-native';
+import UserAgent from 'react-native-user-agent';
+
+export default function UserAgentDemo() {
+  let userAgent: string = UserAgent.getUserAgent();
+  const [webViewUserAgent, setWebViewUserAgent] = useState<string | null>(null);
+  useEffect(() => {
+    UserAgent.getWebViewUserAgent()
+      .then(webViewUserAgent => {
+        setWebViewUserAgent(webViewUserAgent);
+        console.log(webViewUserAgent);
+      })
+      .catch(e => {
+        console.error('Error getting WebView User Agent:', e);
+      });
+  }, []);
+
+  return (
+    <SafeAreaView>
+      <Text style={style.text}>同步方式: </Text>
+      <Text style={style.text}>{userAgent}</Text>
+      <Text style={style.text}></Text>
+      <Text style={style.text}>异步方式: </Text>
+      <Text style={style.text}>{webViewUserAgent}</Text>
+      <Text style={style.text}></Text>
+      <Text style={style.text}>常量: </Text>
+      <Text style={style.text}>systemName: {UserAgent.systemName}</Text>
+      <Text style={style.text}>systemVersion: {UserAgent.systemVersion}</Text>
+      <Text style={style.text}>applicationName: {UserAgent.applicationName}</Text>
+      <Text style={style.text}>applicationVersion: {UserAgent.applicationVersion}</Text>
+      <Text style={style.text}>buildNumber: {UserAgent.buildNumber}</Text>
+    </SafeAreaView>
+  );
+};
+
+const style = StyleSheet.create({
+  text: {
+    fontSize: 18
+  }
+});

--- a/react-native-user-agent/test/UserAgentTest.tsx
+++ b/react-native-user-agent/test/UserAgentTest.tsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import { SafeAreaView, Text, StyleSheet } from 'react-native';
+import UserAgent from 'react-native-user-agent';
+import { Tester, TestCase } from '@rnoh/testerino';
+
+export default function UserAgentTest() {
+  let userAgent: string = UserAgent.getUserAgent();
+  const [webViewUserAgent, setWebViewUserAgent] = useState<string | null>(null);
+  useEffect(() => {
+    UserAgent.getWebViewUserAgent()
+      .then(webViewUserAgent => {
+        setWebViewUserAgent(webViewUserAgent);
+        console.log(webViewUserAgent);
+      })
+      .catch(e => {
+        console.error('Error getting WebView User Agent:', e);
+      });
+  }, []);
+
+  return (
+    <SafeAreaView>
+      <Tester>
+        <TestCase itShould='Get user agent synchronously'>
+          <Text style={style.text}>同步方式: </Text>
+          <Text style={style.text}>{userAgent}</Text>
+        </TestCase>
+
+        <TestCase itShould='Get user agent asynchronously'>
+          <Text style={style.text}>异步方式: </Text>
+          <Text style={style.text}>{webViewUserAgent}</Text>
+        </TestCase>
+
+        <TestCase itShould='A set of constants'>
+          <Text style={style.text}>常量: </Text>
+          <Text style={style.text}>systemName: {UserAgent.systemName}</Text>
+          <Text style={style.text}>systemVersion: {UserAgent.systemVersion}</Text>
+          <Text style={style.text}>applicationName: {UserAgent.applicationName}</Text>
+          <Text style={style.text}>applicationVersion: {UserAgent.applicationVersion}</Text>
+          <Text style={style.text}>buildNumber: {UserAgent.buildNumber}</Text>
+        </TestCase>
+      </Tester>
+    </SafeAreaView>
+  );
+};
+
+const style = StyleSheet.create({
+  text: {
+    fontSize: 18
+  }
+});


### PR DESCRIPTION
# Summary

在demo中, UserAgent已测试的接口方法有getUserAgent,getWebViewUserAgent, 已测试的接口常量有systemName,systemVersion,applicationName,applicationVersion,buildNumber

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)