### PR TITLE
test: 新增react-native-button测试demo和测试用例

### DIFF
--- a/react-native-button/demo/ReactNativeButtonExample.tsx
+++ b/react-native-button/demo/ReactNativeButtonExample.tsx
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';  
+import Button from 'react-native-button';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ReactNativeButtonExample () {
+    
+    const [disabled, setDisabled] = React.useState(false);
+    const [isState, setIsstate] = React.useState(false);
+
+    const _handlePress = () => {
+        setDisabled(!disabled);
+    };
+    
+    const _handleLongPress = () => {
+        setIsstate(!isState);
+    };
+
+    return (
+        <View>
+            <Button
+                style={{ fontSize: 20, color: 'white', backgroundColor: 'green', margin: 20 }}
+                containerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 10, backgroundColor: 'pink', margin: 20 }}
+                disabled={false}
+                accessibilityLabel="The button is press me"
+                childGroupStyle={{backgroundColor: 'black'}}
+                onPress={_handlePress}
+                onLongPress={_handleLongPress}
+            >
+                Press me!
+            </Button>    
+        </View>
+  );
+};
+ 

--- a/react-native-button/test/ReactNativeButtonTest.tsx
+++ b/react-native-button/test/ReactNativeButtonTest.tsx
@@ -1,0 +1,92 @@
+import React, { Component } from 'react';  
+import Button from 'react-native-button';
+import { View, Text, StyleSheet } from 'react-native';
+import { Tester, TestCase, TestSuite } from '@rnoh/testerino';
+
+export function ReactNativeButtonTest() {
+
+    const [disabled, setDisabled] = React.useState(false);
+    const [isState, setIsstate] = React.useState(false);
+
+    const _handlePress = () => {
+        setDisabled(!disabled);
+    };
+
+    const _handleLongPress = () => {
+        setIsstate(!isState);
+    };
+
+    const buttonStyle={ fontSize: 30, color: 'white', backgroundColor: 'green', margin: 20 }
+    const disabledButtonStyle={ fontSize: 30, color: 'grey', backgroundColor: 'lightgrey', margin: 20 }
+
+    const currentStylestate = isState ? disabledButtonStyle : buttonStyle;
+    const title = [
+        disabled ? 'hello':'nihao',
+      ];
+
+    return (
+            <Tester>
+                <Button
+                    style={{ fontSize: 16, color: 'red' }}
+                    containerStyle={{padding: 15, height: 80, width: 80, borderRadius: 40, overflow: 'hidden', backgroundColor: 'pink', margin: 20,
+                    }}
+                >
+                    默认Button
+                </Button>
+
+                <Button
+                    style={{fontSize: 30, color: 'white', margin: 20}}
+                    containerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 10, backgroundColor: 'pink', margin: 20 }}
+                    disabled={true} 
+                    styleDisabled={{fontSize: 40, color: 'red', margin: 20}}
+                    disabledContainerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 60, backgroundColor: 'blue' }}
+                >
+                    {title}
+                </Button>
+
+                <Button
+                    style={currentStylestate}
+                    containerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 10, backgroundColor: 'pink', margin: 20 }}
+                    allowFontScaling={true}
+                    disabled={false} 
+                    onPress={_handlePress}
+                >
+                    {title}
+                </Button>
+
+                <Button
+                    style={currentStylestate}
+                    containerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 10, backgroundColor: 'pink', margin: 20 }}
+                    allowFontScaling={true}
+                    disabled={false} 
+                    onLongPress={_handleLongPress}
+                >
+                    {title}
+                </Button>
+
+                <Button
+                    style={{ fontSize: 20, color: 'white', backgroundColor: 'green', margin: 20 }}
+                    containerStyle={{ padding: 15, overflow: 'hidden', borderRadius: 10, backgroundColor: 'pink', margin: 20 }}
+                    disabled={false}
+                    accessibilityLabel="The button is press me"
+                    childGroupStyle={{backgroundColor: 'black'}}
+                    onPress={() => _handlePress()}
+                    onLongPress={() => _handleLongPress()}
+                >
+                    father!
+                    <Button
+                        style={{color: 'red'}}
+                    >
+                        children1!
+                    </Button>
+
+                    <Button
+                        style={{color: 'white'}}
+                    >
+                        children2!
+                    </Button>
+                </Button>
+
+            </Tester>
+    );
+  };


### PR DESCRIPTION
# Summary
在test中react-native-button组件已测的接口方法有onPress，已测的接口属性有style、containerStyle、disabled、accessibilityLabel、childGroupStyle、styleDisabled、disabledContainerStyle等；

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

