### PR TITLE
test: 新增react-native-idle-timer测试demo和测试用例

### DIFF
--- a/react-native-idle-timer/demo/IdleTimerDemo.tsx
+++ b/react-native-idle-timer/demo/IdleTimerDemo.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import IdleTimerManager from 'react-native-idle-timer';
+
+const IdleTimerExample = () => {  
+  useEffect(() => {
+    // Disable the idle timer to prevent the screen from dimming or locking.
+    IdleTimerManager.setIdleTimerDisabled(true);
+
+    // A cleanup function to re-enable the idle timer when the component is unmounted
+    return () => {
+     IdleTimerManager.setIdleTimerDisabled(false);
+    };
+  }, []);
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>By default, the screen will remain on</Text>
+    </View>
+  );
+};
+export default IdleTimerExample;

--- a/react-native-idle-timer/test/IdleTimerTest.tsx
+++ b/react-native-idle-timer/test/IdleTimerTest.tsx
@@ -1,0 +1,20 @@
+import {Button, SafeAreaView } from 'react-native';
+import IdleTimerManager from 'react-native-idle-timer';
+import { Tester, TestSuite, TestCase } from '@rnoh/testerino';
+// export default IdleTimerExample;
+const IdleTimerTest=()=>{
+    return <SafeAreaView>
+      <Tester>
+      <TestSuite name="test idle_timer">
+        <TestCase itShould="keep screen on">
+          <Button title="Disable Idle Timer" onPress={()=>{alert('Idle timer disabled');IdleTimerManager.setIdleTimerDisabled(true);}} />
+        </TestCase>
+        <TestCase itShould="keep screen off">
+          <Button title="Enable Idle Timer" onPress={()=>{alert('Idle timer enabled');IdleTimerManager.setIdleTimerDisabled(false);}} />
+        </TestCase>
+      </TestSuite>
+    </Tester>
+    </SafeAreaView>
+};
+
+export default IdleTimerTest;


### PR DESCRIPTION

# Summary
在demo中IdleTimerManager组件已测的接口方法有setIdleTimerDisable
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

