### PR TITLE
fix: 修改 react-native-image-crop-picker demo

### DIFF
--- a/react-native-image-crop-picker/ImageCropPickDemo.tsx
+++ b/react-native-image-crop-picker/ImageCropPickDemo.tsx
@@ -1,7 +1,8 @@
 import ImagePicker from 'react-native-image-corp-picker';
 import {openPicker} from 'react-native-image-corp-picker';
-import React {useState} from 'react'
+import React, {useState} from 'react';
 import {Text,StyleSheet,TextInput, View, Button, ScrollView,Switch} from 'react-native'
+
 const ImageCropPickDemo =()=>{
    const TAG:string='ImageCropPickTurboModule';
    const [vulue1,onChangeText1]=useState('');
@@ -586,10 +587,10 @@ const ImageCropPickDemo =()=>{
                                 freeStyleCropEnable:freeStyleCropEnableCropper,
                                 forceJpg:forceJpgCropper,
                                 cropperToolbarTitle:cropperTitle,
-                                cropperChoseText:chooseText,
-                                cropperChoseColor:chooseColor,
-                                croppercCancelText:cancelText,
-                                roppercCancelColor:cancelColor,
+                                cropperChooseText:chooseText,
+                                cropperChooseColor:chooseColor,
+                                cropperCancelText:cancelText,
+                                cropperCancelColor:cancelColor,
                                 cropperRotateButtonsHidden:cropperRotate,
                                 showCropGuidelines:showCropGuidelines,
                                 showCropFrame:showCropFrame
@@ -670,15 +671,13 @@ const styles = StyleSheet.create({
       width:50,
       height:30,
       color:'black',
-      borderColor:'gray',
-      borderWidth:1
+      backgroundColor: 'lightblue',
      },
      textInput:{
         width:'50%',
         height:36,
         color:'black',
-        borderColor:'gray',
-        bordeWidth:1
+        backgroundColor: 'lightblue',
      },
      switchType:{
         width:60,
@@ -700,3 +699,5 @@ const styles = StyleSheet.create({
         marginTop:10,
      }
 })
+
+export default ImageCropPickDemo;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- close #888 
- 修改 react-native-image-crop-picker demo


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

![image](https://github.com/user-attachments/assets/aedc8ff5-80e6-41d8-b967-f3a935b80a21)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

