### PR TITLE
fix:新增ant-design-mobile-rn测试demo缺少的Tester

### DIFF
--- a/ant-design-mobile-rn/AntDesignMobile.tsx
+++ b/ant-design-mobile-rn/AntDesignMobile.tsx
@@ -44,55 +44,57 @@ import CheckboxTest from './CheckboxTest';
 import ToastTest from './ToastTest';
 import LocaleProviderTest from './LocaleProviderTest';
 import { NavigationContainer, Page } from '../../components';
+import { Tester } from '@rnoh/testerino';
 
 export function AntDesignMobile() {
   return (
     <NavigationContainer>
       <ScrollView nestedScrollEnabled={true}>
-        <Page name='ButtonAntTest'><ButtonAntTest /></Page>
-        <Page name='AccordionTest'><AccordionTest /></Page>
-        <Page name='ActionSheetTest'><ActionSheetTest /></Page>
-        <Page name='CardTest'><CardTest /></Page>
-        <Page name='ListTest'><ListTest /></Page>
-        <Page name='ResultTest'><ResultTest /></Page>
-        <Page name='ToastTest'><ToastTest /></Page>
-        <Page name='ActivityIndicatorTest'><ActivityIndicatorTest /></Page>
-        <Page name='BadgeTest'><BadgeTest /></Page>
-        <Page name='TabBarTest'><TabBarTest /></Page>
-        <Page name='SearchBarTest'><SearchBarTest /></Page>
-        <Page name='NoticeBarTest'><NoticeBarTest /></Page>
-        <Page name='WingBlankTest'><WingBlankTest /></Page>
-        <Page name='WhiteSpaceTest'><WhiteSpaceTest /></Page>
-        <Page name='ViewTest'><ViewTest /></Page>
-        <Page name='GridTest'><GridTest /></Page>
-        <Page name='FlexTest'><FlexTest /></Page>
-        <Page name='TextareaItemTest'><TextareaItemTest /></Page>
-        <Page name='TagsTest'><TagsTest /></Page>
-        <Page name='SwitchTest'><SwitchTest /></Page>
-        <Page name='StepperTest'><StepperTest /></Page>
-        <Page name='RadioTest'><RadioTest /></Page>
-        <Page name='PaginationTest'><PaginationTest /></Page>
-        <Page name='ProgressTest'><ProgressTest /></Page>
-        <Page name='InputItemTest'><InputItemTest /></Page>
-        <Page name='CheckboxTest'><CheckboxTest /></Page>
-        <Page name='StepsTest'><StepsTest /></Page>
-        <Page name='CarouselTest'><CarouselTest /></Page>
-        <Page name='PortalTest'><PortalTest /></Page>
-        <Page name='LocaleProviderTest'><LocaleProviderTest /></Page>
-        <Page name='DatePickerViewTest'><DatePickerViewTest /></Page>
-        <Page name='IconAntTest'><IconAntTest /></Page>
-        <Page name='SegmentedControlTest'><SegmentedControlTest /></Page>
-        <Page name='DatePickerTest'><DatePickerTest /></Page>
-        <Page name='PickerTest'><PickerTest /></Page>
-        <Page name='PickerViewTest'><PickerViewTest /></Page>
-        <Page name='TabsTest'><TabsTest /></Page>
-        <Page name='ModalTest'><ModalTest /></Page>
-        <Page name='SliderAntTest'><SliderAntTest /></Page>
-        <Page name='ListViewTest'><ListViewTest /></Page>
-        <Page name='PopoverTest'><PopoverTest /></Page>
-
-        <Page name='SwipeActionTest'><SwipeActionTest /></Page>
-        <Page name='DrawerTest'><DrawerTest /></Page>
+        <Tester style={{ flex: 1 }}>
+          <Page name='ButtonAntTest'><ButtonAntTest /></Page>
+          <Page name='AccordionTest'><AccordionTest /></Page>
+          <Page name='ActionSheetTest'><ActionSheetTest /></Page>
+          <Page name='CardTest'><CardTest /></Page>
+          <Page name='ListTest'><ListTest /></Page>
+          <Page name='ResultTest'><ResultTest /></Page>
+          <Page name='ToastTest'><ToastTest /></Page>
+          <Page name='ActivityIndicatorTest'><ActivityIndicatorTest /></Page>
+          <Page name='BadgeTest'><BadgeTest /></Page>
+          <Page name='TabBarTest'><TabBarTest /></Page>
+          <Page name='SearchBarTest'><SearchBarTest /></Page>
+          <Page name='NoticeBarTest'><NoticeBarTest /></Page>
+          <Page name='WingBlankTest'><WingBlankTest /></Page>
+          <Page name='WhiteSpaceTest'><WhiteSpaceTest /></Page>
+          <Page name='ViewTest'><ViewTest /></Page>
+          <Page name='GridTest'><GridTest /></Page>
+          <Page name='FlexTest'><FlexTest /></Page>
+          <Page name='TextareaItemTest'><TextareaItemTest /></Page>
+          <Page name='TagsTest'><TagsTest /></Page>
+          <Page name='SwitchTest'><SwitchTest /></Page>
+          <Page name='StepperTest'><StepperTest /></Page>
+          <Page name='RadioTest'><RadioTest /></Page>
+          <Page name='PaginationTest'><PaginationTest /></Page>
+          <Page name='ProgressTest'><ProgressTest /></Page>
+          <Page name='InputItemTest'><InputItemTest /></Page>
+          <Page name='CheckboxTest'><CheckboxTest /></Page>
+          <Page name='StepsTest'><StepsTest /></Page>
+          <Page name='CarouselTest'><CarouselTest /></Page>
+          <Page name='PortalTest'><PortalTest /></Page>
+          <Page name='LocaleProviderTest'><LocaleProviderTest /></Page>
+          <Page name='DatePickerViewTest'><DatePickerViewTest /></Page>
+          <Page name='IconAntTest'><IconAntTest /></Page>
+          <Page name='SegmentedControlTest'><SegmentedControlTest /></Page>
+          <Page name='DatePickerTest'><DatePickerTest /></Page>
+          <Page name='PickerTest'><PickerTest /></Page>
+          <Page name='PickerViewTest'><PickerViewTest /></Page>
+          <Page name='TabsTest'><TabsTest /></Page>
+          <Page name='ModalTest'><ModalTest /></Page>
+          <Page name='SliderAntTest'><SliderAntTest /></Page>
+          <Page name='ListViewTest'><ListViewTest /></Page>
+          <Page name='PopoverTest'><PopoverTest /></Page>
+          <Page name='SwipeActionTest'><SwipeActionTest /></Page>
+          <Page name='DrawerTest'><DrawerTest /></Page>
+        </Tester>
       </ScrollView>
     </NavigationContainer>
   )


### PR DESCRIPTION
# Summary

新增ant-design-mobile-rn测试demo缺少的Tester

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

