### PR TITLE
test:修改react-native-permissions的测试用例、demo

### DIFF
--- a/react-native-permissions/testCase/TestCase.tsx
+++ b/react-native-permissions/testCase/TestCase.tsx
@@ -221,6 +221,30 @@ export const PermissionTest = () => {
                             expect(state).to.be.true;
                         }}
                     />
+                    <TestCase
+                        key={"getInitStatus_8"}
+                        itShould={`openPhotoPicker change`}
+                        tags={['C_API']}
+                        initialState={false}
+
+                        arrange={({ setState }) => {
+
+                            return (
+                                <View style={{ flex: 1 }}>
+                                    <Button title="打开图片选择"
+                                        onPress={async () => {
+                                            let check = await RTNPermissions.openPhotoPicker();
+
+                                            setState(true)
+
+                                        }}></Button>
+                                </View>
+                            );
+                        }}
+                        assert={async ({ expect, state }) => {
+                            expect(state).to.be.true;
+                        }}
+                    />
 
                 </TestSuite>
 


### PR DESCRIPTION


# Summary
修改react-native-permissions的测试用例、demo
已测的接口：check、checkNotifications、openSettings、request、requestNotifications、checkMultiple、requestMultiple、openPhotoPicker
未测的接口：checkLocationAccuracy、requestLocationAccuracy、



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


