### PR TITLE
test: 修改flash-list库demo的CellRendererComponent属性的动画加载时间过长问题

### DIFF
--- a/@shopify/flash-list/FlashListDemo4.tsx
+++ b/@shopify/flash-list/FlashListDemo4.tsx
@@ -17,6 +17,7 @@ const CustomCellRendererComponent = React.forwardRef((props: any, _) => {
       Animated.delay(props.index * 50),
       Animated.spring(offset, {
         toValue: 0,
+        useNativeDriver: true,
       }),
     ]).start();
   }, [props.index]);

--- a/@shopify/flash-list/test/FlashListTest.tsx
+++ b/@shopify/flash-list/test/FlashListTest.tsx
@@ -501,6 +501,7 @@ export const FlashListTest = () => {
                 Animated.delay(props.index * 50),
                 Animated.spring(offset, {
                     toValue: 0,
+                    useNativeDriver: true,
                 }),
             ]).start();
         }, [props.index]);


### PR DESCRIPTION
# Summary

修改flash-list库demo的CellRendererComponent属性的动画执行方式来处理加载时间过长问题

## Test Plan
问题现象：CellRendererComponent属性的动画加载时间过长
分析：可通过设置setNativeDriver来使用设备渲染（不通过js渲染形式实现）动画来缩短加载时长
结果：使用setNativeDriver后动画可以快速执行



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


