### PR TITLE
test：按照要求新增react-native-callkeep测试用例和demo

### DIFF
--- a/react-native-callkeep/CallKeepDemo.tsx
+++ b/react-native-callkeep/CallKeepDemo.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Button,
+    View,
+    Alert,
+    Text,
+} from 'react-native';
+
+import RNCallKeep from 'react-native-callkeep';
+
+export function CallKeepExample() {
+    const handleClick = (buttonId: number) => {
+        switch (buttonId) {
+            case 1:
+                RNCallKeep.startCall("0x123456", "10086");
+                break;
+            case 2:
+                RNCallKeep.isCallActive("0x123456").then(res => {
+                    Alert.alert('获取isCallActive的值:' + res);
+                });
+                break;
+            case 3:
+                RNCallKeep.checkIfBusy().then(res => {
+                    Alert.alert('获取checkIfBusy的值:' + res);
+                });
+                break;
+
+            default:
+                break;
+        }
+    };
+    return (
+        <>
+            <Text style={{ color: "red" }}>RNCallKeep.startCall</Text>
+            <Button title='startCall' onPress={() => handleClick(1)} ></Button>
+
+            <Text style={{ color: "red" }}>RNCallKeep.isCallActive</Text>
+            <Button title='isCallActive' onPress={() => handleClick(2)} ></Button>
+
+            <Text style={{ color: "red" }}>RNCallKeep.checkIfBusy</Text>
+            <Button title='checkIfBusy' onPress={() => handleClick(3)} ></Button>
+        </>
+    );
+}

--- a/react-native-callkeep/test/CallKeepTestCase.tsx
+++ b/react-native-callkeep/test/CallKeepTestCase.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Button,
+    View,
+    Alert,
+    Text,
+    ScrollView,
+} from 'react-native';
+import {
+    Tester,
+    TestSuite,
+    TestCase
+} from '@rnoh/testerino';
+
+import RNCallKeep from 'react-native-callkeep';
+
+export function CallKeepTestCase() {
+
+    return (
+        <View style={styles.screen}>
+            <Tester style={{ flex: 1, backgroundColor: 'black' }}>
+                <ScrollView>
+                    <TestSuite name="CallKeep test">
+                        <View style={styles.container}>
+                            <TestCase itShould="test_01 callkeep startCall" tags={['C_API']} //跳转到拨号界面
+                                initialState={undefined as any}
+                                arrange={({ setState }) => {
+                                    return (
+                                        <Button title={'startCall'} onPress={() => { RNCallKeep.startCall("0x123456", "999"), setState(true) }} />
+                                    );
+                                }}
+                                assert={({ expect, state }) => { expect(state).to.be.true }} />
+
+
+                            <TestCase itShould="test_02 callkeep isCallActive" tags={['C_API']} //判断当前电话是否已接
+                                initialState={undefined as any}
+                                arrange={({ setState }) => {
+                                    return (
+                                        <View>
+                                            <Button
+                                                title={'isCallActive'}
+                                                onPress={() => { RNCallKeep.isCallActive("0x123456").then(res => { setState(res) }) }}
+                                            />
+                                        </View>
+                                    );
+                                }}
+                                assert={({ expect, state }) => { expect(state).to.be.true }} />
+
+
+                            <TestCase itShould="test_03 callkeep checkIfBusy" tags={['C_API']}//判断当前是否有通话存
+                                initialState={undefined as any}
+                                arrange={({ setState }) => {
+                                    return (
+                                        <View>
+                                            <Button
+                                                title={'checkIfBusy'}
+                                                onPress={() => { RNCallKeep.checkIfBusy().then(res => setState(res)) }}
+                                            />
+                                        </View>
+                                    );
+                                }}
+                                assert={({ expect, state }) => { expect(state).to.be.true }} />
+                        </View>
+                    </TestSuite>
+                </ScrollView>
+            </Tester>
+        </View >
+    );
+}
+
+const styles = {
+    screen: {
+        flex: 1,
+        padding: 4,
+        paddingTop: 10,
+        backgroundColor: 'black',
+    },
+    container: {
+        marginHorizontal: 4,
+        marginVertical: 8,
+        paddingHorizontal: 8,
+    },
+};


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。-->

请解释此次更改的 **动机**，以下是一些帮助您的要点：
- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
这个PR主要是提交react-native-callkeep这个RN三方库适配HOMS的测试用例和测试demo，不涉及到issues

- 这个功能是什么？
主要是写react-native-callkeep测试用例来测试HMOS功能是否实现

- 您是如何实现解决方案的？
编写[CallKeepTestCase.tsx和CallKeepDemo.tsx文件

- 这个更改影响了库的哪些部分？
不影响库，只针对测试用例编写

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
测试demo路径：https://github.com/react-native-oh-library/RNOHDCS/tree/main

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->
- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)