### PR TITLE
fix:react-native-vision-camera库的拍照demo添加1X和1.4X按钮

### DIFF
--- a/react-native-vision-camera/PhotoDemo.tsx
+++ b/react-native-vision-camera/PhotoDemo.tsx
@@ -93,6 +93,12 @@ export default function PhotoDemo() {
   const changeZoom = () => {
     setZoom(getRandomNumber(0.48, 15));
   };
+  const changeZoom1X = () => {
+    setZoom(1);
+  };
+  const changeZoom14X = () => {
+    setZoom(1.4);
+  };
   const changeExposure = () => {
     setExposure(exposure === 4 ? -4 : 4);
   };
@@ -214,6 +220,8 @@ export default function PhotoDemo() {
               title="androidPreviewViewType"
               onPress={changeAndroidPreviewViewType}></Button>
             <Button title="zoom" onPress={changeZoom}></Button>
+            <Button title="zoom1x" onPress={changeZoom1X}></Button>
+            <Button title="zoom1.4x" onPress={changeZoom14X}></Button>
             <Button
               title="photoQualityBalance"
               onPress={changePhotoQualityBalance}></Button>


### PR DESCRIPTION
# Summary

react-native-vision-camera库的拍照demo添加1X和1.4X按钮


## Test Plan

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
