### PR TITLE
test: 更改 react-native-svg 测试用例

### DIFF
--- a/react-native-svg/tester/svgDemoCases/components/genRect.tsx
+++ b/react-native-svg/tester/svgDemoCases/components/genRect.tsx
@@ -11,8 +11,8 @@ import {
 const basicProps = {
   width: 80,
   height: 80,
-  fill: 'red',
-  strokeWidth: '1',
+  fill: 'grey',
+  strokeWidth: '2',
 };
 
 const basicCases: CaseParams[] = [

--- a/react-native-svg/tester/svgDemoCases/genUtil.tsx
+++ b/react-native-svg/tester/svgDemoCases/genUtil.tsx
@@ -285,41 +285,9 @@ export function genViewProps(): CaseParams[] {
             ]
         },
         {
-            key: 'hitSlop',
-            values: [
-                {
-                    top: 0,
-                    left: 0,
-                    bottom: 0,
-                    right: 0
-                },
-                {
-                    top: 10,
-                    left: 10,
-                    bottom: 10,
-                    right: 10
-                },
-                {
-                    top: 30,
-                    left: 30,
-                    bottom: 0,
-                    right: 0
-                },
-            ]
-        },
-        {
             key: 'pointerEvents', // 'box-none' | 'none' | 'box-only' | 'auto' | undefined;
             values: ['box-none', 'none', 'box-only', 'auto']
         },
-        {
-            key: 'removeClippedSubviews',
-            values: [true, false]
-        },
-        // testID nativeID
-        {
-            key: 'shouldRasterizeIOS',
-            values: [true, false]
-        }
     ]
 }
 


### PR DESCRIPTION
# Summary

- 更改 rect 中的底色为 grey，strokeWidth为2，删除非SVG标准库属性

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
