### PR TITLE
test: 新增flash-list测试用例的导航索引文件

### DIFF
--- a/@shopify/flash-list/test/TestIndex.tsx
+++ b/@shopify/flash-list/test/TestIndex.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { StatusBar, StyleSheet, FlatList, Text, Pressable } from "react-native";
+import { NavigationContainer, useNavigation } from "@react-navigation/native";
+import { createStackNavigator, StackNavigationProp } from "@react-navigation/stack";
+
+import FlashlistDemo2 from "./FlashListDemo2";
+import { FlashListTest } from "./FlashListTest";
+
+interface ExampleItem {
+  title: string;
+  destination: keyof RootStackParamList;
+}
+
+export type RootStackParamList = {
+  Example: undefined;
+  Example1: undefined;
+  Example2: undefined;
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+const NavigationTree = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Example">
+        <Stack.Screen name="Example" component={HomeScreen} />
+        <Stack.Screen name="Example1" component={FlashListTest} />
+        <Stack.Screen name="Example2" component={FlashlistDemo2} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const HomeScreen = () => {
+  const { navigate } =
+    useNavigation<StackNavigationProp<RootStackParamList, "Example">>();
+
+  const data: ExampleItem[] = [
+    { title: "Example", destination: "Example" },
+    { title: "Example1", destination: "Example1" },
+    { title: "Example2", destination: "Example2" }
+  ];
+  return (
+    <FlatList
+      testID="ExamplesFlatList"
+      keyExtractor={(item) => item.destination}
+      data={data}
+      renderItem={({ item }) => (
+        <Pressable
+          style={styles.row}
+          onPress={() => {
+            navigate(item.destination);
+          }}
+          testID={item.title}
+        >
+          <Text style={styles.rowTitle}>{item.title}</Text>
+        </Pressable>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    padding: 16,
+    backgroundColor: "#FFF",
+    borderBottomWidth: 1,
+    borderBottomColor: "#EFEFEF",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  rowTitle: {
+    fontSize: 18,
+  },
+});
+
+
+export default NavigationTree;


### PR DESCRIPTION

# Summary

test: 新增flash-list测试用例的导航索引文件


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

