### PR TITLE
test: 增加ScrollView到react-native-image-capinsets-next测试用例和demo

### DIFF
--- a/react-native-image-capinsets-next/demo/ImageCapInsetsDemo.tsx
+++ b/react-native-image-capinsets-next/demo/ImageCapInsetsDemo.tsx
@@ -1,6 +1,6 @@
 import ImageCapInset from '@react-native-oh-tpl/react-native-image-capinsets-next';
 import React, {useState} from 'react';
-import {View, StyleSheet, Text, Switch} from 'react-native';
+import {View, StyleSheet, Text, Switch, ScrollView} from 'react-native';
 import { Tester, TestCase, TestSuite } from "@rnoh/testerino";
 
 const YourImage = () => {
@@ -38,6 +38,7 @@ const YourImage = () => {
   };
 
   return (
+    <ScrollView>
     <Tester>
       <TestSuite name="react native image capinsets next">
         <TestCase itShould="react native image capinsets next load locale picture">
@@ -104,6 +105,7 @@ const YourImage = () => {
         </TestCase>
       </TestSuite>
   </Tester>
+  </ScrollView>
   );
 };
 

--- a/react-native-image-capinsets-next/test/ImageCapInsetsTest.tsx
+++ b/react-native-image-capinsets-next/test/ImageCapInsetsTest.tsx
@@ -1,6 +1,6 @@
 import ImageCapInset from '@react-native-oh-tpl/react-native-image-capinsets-next';
 import React, {useState} from 'react';
-import {View, StyleSheet, Text, Switch} from 'react-native';
+import {View, StyleSheet, Text, Switch, ScrollView } from 'react-native';
 import { Tester, TestCase, TestSuite } from "@rnoh/testerino";
 
 const YourImage = () => {
@@ -38,6 +38,7 @@ const YourImage = () => {
   };
 
   return (
+    <ScrollView>
     <Tester>
       <TestSuite name="react native image capinsets next">
         <TestCase itShould="react native image capinsets next load locale picture">
@@ -104,6 +105,7 @@ const YourImage = () => {
         </TestCase>
       </TestSuite>
   </Tester>
+  </ScrollView>
   );
 };
 


### PR DESCRIPTION

# Summary

test: 增加ScrollView到react-native-image-capinsets-next测试用例和demo

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

