### PR TITLE
test: 修改react-native-image-capinsets-next的demo和测试用例展示问题修复

### DIFF
--- a/react-native-image-capinsets-next/demo/ImageCapInsetsDemo.tsx
+++ b/react-native-image-capinsets-next/demo/ImageCapInsetsDemo.tsx
@@ -14,32 +14,19 @@ const YourImage = () => {
 
   const [currentImg1, setCurrentImg1] = useState(img1);
   const [currentImg2, setCurrentImg2] = useState(img3);
-  const [currentImg11, setCurrentImg11] = useState(img1);
-  const [currentImg22, setCurrentImg22] = useState(img3);
 
   const [currentCapInset1, setCurrentCapInset1] = useState(JSON.parse(initInset));
   const [currentCapInset2, setCurrentCapInset2] = useState(JSON.parse(initInset));
-  const [currentCapInset11, setCurrentCapInset11] = useState(JSON.parse(initInset));
-  const [currentCapInset22, setCurrentCapInset22] = useState(JSON.parse(initInset));
+
   
   const onChangeUrl1 = () => {
     const url = currentImg1 === img1 ? img2 : img1;
     setCurrentImg1(url);
   };
 
-  const onChangeUrl11 = () => {
-    const url = currentImg11 === img1 ? img2 : img1;
-    setCurrentImg11(url);
-  };
-
   const onChangeUrl2 = () => {
     const url = currentImg2 === img3 ? img4 : img3;
     setCurrentImg2(url);
-  };
-
-  const onChangeUrl22 = () => {
-    const url = currentImg22 === img3 ? img4 : img3;
-    setCurrentImg22(url);
   };
 
   const onChangeInset1 = () => {
@@ -48,204 +35,76 @@ const YourImage = () => {
     setCurrentCapInset1(JSON.parse(inset));
   };
 
-  const onChangeInset11 = () => {
-    const inset =
-      JSON.stringify(currentCapInset11) === initInset ? initInset2 : initInset;
-    setCurrentCapInset11(JSON.parse(inset));
-  };
-
   const onChangeInset2 = () => {
     const inset =
       JSON.stringify(currentCapInset2) === initInset ? initInset2 : initInset;
     setCurrentCapInset2(JSON.parse(inset));
   };
 
-  const onChangeInset22 = () => {
-    const inset =
-      JSON.stringify(currentCapInset22) === initInset ? initInset2 : initInset;
-    setCurrentCapInset22(JSON.parse(inset));
-  };
 
   return (
     <ScrollView>
-    <Tester>
-      <TestSuite name="react native image capinsets next load locale picture property Source">
-        <TestCase itShould="toggle the property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={currentImg1}
-                capInsets={JSON.parse(initInset)}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换本地图片source: </Text>
-                <Switch
-                  trackColor={{false: '#767577', true: '#81b0ff'}}
-                  thumbColor={currentImg1 === img1 ? '#f5dd4b' : '#f4f3f4'}
-                  ios_backgroundColor="#3e3e3e"
-                  onValueChange={onChangeUrl1}
-                  value={currentImg1 === img1 ? true : false}
-                />
-              </View>
-            </View>
-          </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property Source">
-          <TestCase itShould="toggle the property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={currentImg11}
-                capInsets={JSON.parse(initInset2)}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换本地图片source: </Text>
-                <Switch
-                  trackColor={{false: '#767577', true: '#81b0ff'}}
-                  thumbColor={currentImg11 === img1 ? '#f5dd4b' : '#f4f3f4'}
-                  ios_backgroundColor="#3e3e3e"
-                  onValueChange={onChangeUrl11}
-                  value={currentImg11 === img1 ? true : false}
-                />
-              </View>
-            </View>
-          </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property CapInset">
-          <TestCase itShould="toggle the property CapInset">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={img1}
-                capInsets={currentCapInset1}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换本地图片capinset: </Text>
-                <Switch
-                  thumbColor={currentCapInset1 === initInset ? '#f5dd4b' : '#f4f3f4'}
-                  onValueChange={onChangeInset1}
-                  value={JSON.stringify(currentCapInset1) === initInset ? true : false}
-                />
-              </View>
-              <View style={styles.instruction}>
-                  <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
-                  <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
-              </View>
-            </View>
-          </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property CapInset">
-          <TestCase itShould="toggle the property CapInset">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={img2}
-                capInsets={currentCapInset11}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换本地图片capinset: </Text>
-                <Switch
-                  thumbColor={currentCapInset11 === initInset ? '#f5dd4b' : '#f4f3f4'}
-                  onValueChange={onChangeInset11}
-                  value={JSON.stringify(currentCapInset11) === initInset ? true : false}
-                />
-              </View>
-              <View style={styles.instruction}>
-                  <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
-                  <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
-              </View>
-            </View>
-          </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load network picture property Source">
-          <TestCase itShould="toggle property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={{uri: currentImg2}}
-                capInsets={JSON.parse(initInset)}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换网络图片source: </Text>
-                <Switch
-                  trackColor={{false: '#767577', true: '#81b0ff'}}
-                  thumbColor={currentImg2 === img3 ? '#f5dd4b' : '#f4f3f4'}
-                  ios_backgroundColor="#3e3e3e"
-                  onValueChange={onChangeUrl2}
-                  value={currentImg2 === img3 ? true : false}
-                />
-              </View>
+
+        <View style={styles.container}>
+          <ImageCapInset
+            style={styles.imgStyle}
+            source={currentImg1}
+            capInsets={currentCapInset1}>
+          </ImageCapInset>
+          <View style={styles.switchItem}>
+            <Text>切换本地图片source: </Text>
+            <Switch
+              trackColor={{false: '#767577', true: '#81b0ff'}}
+              thumbColor={currentImg1 === img1 ? '#f5dd4b' : '#f4f3f4'}
+              ios_backgroundColor="#3e3e3e"
+              onValueChange={onChangeUrl1}
+              value={currentImg1 === img1 ? true : false}
+            />
           </View>
-        </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Source">
-        <TestCase itShould="toggle property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={{uri: currentImg22}}
-                capInsets={JSON.parse(initInset2)}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换网络图片source: </Text>
-                <Switch
-                  trackColor={{false: '#767577', true: '#81b0ff'}}
-                  thumbColor={currentImg22 === img3 ? '#f5dd4b' : '#f4f3f4'}
-                  ios_backgroundColor="#3e3e3e"
-                  onValueChange={onChangeUrl22}
-                  value={currentImg22 === img3 ? true : false}
-                />
-              </View>
+          <View style={styles.switchItem}>
+            <Text>切换本地图片capinset: </Text>
+            <Switch
+              thumbColor={currentCapInset1 === initInset ? '#f5dd4b' : '#f4f3f4'}
+              onValueChange={onChangeInset1}
+              value={JSON.stringify(currentCapInset1) === initInset ? true : false}
+            />
           </View>
-        </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Capinset">
-        <TestCase itShould="toggle property Capinset">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={{uri: img3}}
-                capInsets={currentCapInset2}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换网络图片capinset: </Text>
-                <Switch
-                  thumbColor={currentCapInset2 === initInset ? '#f5dd4b' : '#f4f3f4'}
-                  onValueChange={onChangeInset2}
-                  value={JSON.stringify(currentCapInset2) === initInset ? true : false}
-                />
-              </View>
-              <View style={styles.instruction}>
-                <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
-                <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
-              </View>
+          <View style={styles.instruction}>
+              <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
+              <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
           </View>
-        </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Capinset">
-        <TestCase itShould="toggle property Capinset">
-            <View style={styles.container}>
-              <ImageCapInset
-                style={styles.imgStyle}
-                source={{uri: img4}}
-                capInsets={currentCapInset22}>
-              </ImageCapInset>
-              <View style={styles.switchItem}>
-                <Text>切换网络图片capinset: </Text>
-                <Switch
-                  thumbColor={currentCapInset22 === initInset ? '#f5dd4b' : '#f4f3f4'}
-                  onValueChange={onChangeInset22}
-                  value={JSON.stringify(currentCapInset22) === initInset ? true : false}
-                />
-              </View>
-              <View style={styles.instruction}>
-                <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
-                <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
-              </View>
+        </View>
+          
+        <View style={styles.container}>
+          <ImageCapInset
+            style={styles.imgStyle}
+            source={{uri: currentImg2}}
+            capInsets={currentCapInset2}>
+          </ImageCapInset>
+          <View style={styles.switchItem}>
+            <Text>切换网络图片source: </Text>
+            <Switch
+              trackColor={{false: '#767577', true: '#81b0ff'}}
+              thumbColor={currentImg2 === img3 ? '#f5dd4b' : '#f4f3f4'}
+              ios_backgroundColor="#3e3e3e"
+              onValueChange={onChangeUrl2}
+              value={currentImg2 === img3 ? true : false}
+            />
           </View>
-        </TestCase>
-        </TestSuite>
-  </Tester>
+          <View style={styles.switchItem}>
+            <Text>切换网络图片capinset: </Text>
+            <Switch
+              thumbColor={currentCapInset2 === initInset ? '#f5dd4b' : '#f4f3f4'}
+              onValueChange={onChangeInset2}
+              value={JSON.stringify(currentCapInset2) === initInset ? true : false}
+            />
+          </View>
+          <View style={styles.instruction}>
+            <Text>开关关闭capinset值: top: 15, right: 20, bottom: 15, left: 20</Text>
+            <Text>开关打开capinset值: top: 2, right: 5, bottom: 2, left: 5</Text>
+          </View>
+      </View>
+
   </ScrollView>
   );
 };

--- a/react-native-image-capinsets-next/test/ImageCapInsetsTest.tsx
+++ b/react-native-image-capinsets-next/test/ImageCapInsetsTest.tsx
@@ -69,8 +69,8 @@ const YourImage = () => {
   return (
     <ScrollView>
     <Tester>
-      <TestSuite name="react native image capinsets next load locale picture property Source">
-        <TestCase itShould="toggle the property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
+      <TestSuite name="react native image capinsets next">
+        <TestCase itShould="load locale picture 01: toggle the property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -89,9 +89,8 @@ const YourImage = () => {
               </View>
             </View>
           </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property Source">
-          <TestCase itShould="toggle the property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
+          
+          <TestCase itShould="load locale picture 02: toggle the property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -110,9 +109,8 @@ const YourImage = () => {
               </View>
             </View>
           </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property CapInset">
-          <TestCase itShould="toggle the property CapInset">
+          
+          <TestCase itShould="load locale picture 03: toggle the property CapInset">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -133,9 +131,8 @@ const YourImage = () => {
               </View>
             </View>
           </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load locale picture property CapInset">
-          <TestCase itShould="toggle the property CapInset">
+          
+          <TestCase itShould="load locale picture 04: toggle the property CapInset">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -156,9 +153,8 @@ const YourImage = () => {
               </View>
             </View>
           </TestCase>
-          </TestSuite>
-          <TestSuite name="react native image capinsets next load network picture property Source">
-          <TestCase itShould="toggle property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
+          
+          <TestCase itShould="load network picture 05: toggle property Source with capinset {top: 2, right: 5, bottom: 2, left: 5}">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -177,9 +173,8 @@ const YourImage = () => {
               </View>
           </View>
         </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Source">
-        <TestCase itShould="toggle property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
+        
+        <TestCase itShould="load network picture 06: toggle property Source with capinset {top: 15, right: 20, bottom: 15, left: 20}">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -198,9 +193,8 @@ const YourImage = () => {
               </View>
           </View>
         </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Capinset">
-        <TestCase itShould="toggle property Capinset">
+        
+        <TestCase itShould="load network picture 07: toggle property Capinset">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -221,9 +215,8 @@ const YourImage = () => {
               </View>
           </View>
         </TestCase>
-        </TestSuite>
-        <TestSuite name="react native image capinsets next load network picture property Capinset">
-        <TestCase itShould="toggle property Capinset">
+        
+        <TestCase itShould="load network picture 08: toggle property Capinset">
             <View style={styles.container}>
               <ImageCapInset
                 style={styles.imgStyle}
@@ -244,7 +237,7 @@ const YourImage = () => {
               </View>
           </View>
         </TestCase>
-        </TestSuite>
+      </TestSuite>
   </Tester>
   </ScrollView>
   );


### PR DESCRIPTION

# Summary

test: 修改react-native-image-capinsets-next的demo和测试用例展示问题修复

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
