### PR TITLE
test:修改react-native-nfc-manager的测试用例

### DIFF
--- a/react-native-nfc-manager/NfcManagerDemo.tsx
+++ b/react-native-nfc-manager/NfcManagerDemo.tsx
@@ -621,19 +621,19 @@ const RequestTechnologyProps = [
 ]
 
  return (
+   <View>
+      <View>
+        <Text>Scan a Tag result:</Text>
+        <Text style={styles.baseText}>
+              返回结果(进行卡片操作时，请先通过ScanTag()扫描设备，获取当前卡片支持的标签):
+        </Text>
+        <Text style={styles.inputArea}>
+              {text}
+        </Text>
+      </View>
    <ScrollView>
      <Tester>
       <TestSuite name='NfcManagerDemo'>
-         <TestCase itShould="Scan a Tag result:">
-          <View>
-            <Text style={styles.baseText}>
-              返回结果(进行卡片操作时，请先通过ScanTag()扫描设备，获取当前卡片支持的标签):
-            </Text>
-            <Text style={styles.inputArea}>
-              {text}
-            </Text>
-          </View>
-        </TestCase>
        <TestCase itShould="function:isSupported()(该接口判断设备是否支持nfc)"  initialState={false} arrange={({ setState }) => (
           <Button title='运行' color='#841584' onPress={async () => {
               let isSupported = await onSupported();
@@ -1136,6 +1136,7 @@ const RequestTechnologyProps = [
       </TestSuite>
      </Tester>
     </ScrollView>
+    </View>
   );
 }
 


### PR DESCRIPTION
# Summary
修改react-native-nfc-manager的测试用例
1.使状态显示的地方保持固定，不会随整体界面的滑动而隐藏

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
