### PR TITLE
test：修改react-native-incall-manager测试demo的顶部文本颜色

### DIFF
--- a/react-native-incall-manager/test/InCallManagerTest.tsx
+++ b/react-native-incall-manager/test/InCallManagerTest.tsx
@@ -235,27 +235,27 @@ export default function InCallManagerTest() {
         <Tester key={"InCallManagerTest"} style={{ flex: 1 }}>
 
             <View>
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     EVENT Emit:
                 </Text>
 
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     proximityEvent:{JSON.stringify(proximityEvent)}
                 </Text>
 
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     wiredHeadsetEvent:{JSON.stringify(wiredHeadsetEvent)}
                 </Text>
 
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     noisyAudioEvent(iOS不支持):{JSON.stringify(noisyAudioEvent)}
                 </Text>
 
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     mediaButtonEvent(iOS不支持):{JSON.stringify(mediaButtonEvent)}
                 </Text>
 
-                <Text numberOfLines={0} style={{ color: 'blue' }}>
+                <Text numberOfLines={0} style={{ color: '#ffffff' }}>
                     onAudioFocusChange(iOS不支持):{JSON.stringify(onAudioFocusChange)}
                 </Text>
 


### PR DESCRIPTION
# Summary

- 修改react-native-incall-manager测试demo的顶部文本颜色。
- closes: #1411 

## Test Plan

## Checklist
- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
