### PR TITLE
test: 新增affinityCalculationStrategy和autoskip用例

### DIFF
--- a/react-native-text-input-mask/demo/TextInputDemo.tsx
+++ b/react-native-text-input-mask/demo/TextInputDemo.tsx
@@ -15,7 +15,7 @@ interface OtherControlProps {
 
 const BasicTextInputMaskDemo: React.FC<
   TextInputMaskProps & OtherControlProps
-> = props => {
+> = (props) => {
   const [formatedValue, setFormatedValue] = useState('');
   const [extractedValue, setExtractedValue] = useState('');
 
@@ -32,7 +32,8 @@ const BasicTextInputMaskDemo: React.FC<
   return (
     <View style={styles.container}>
       <View
-        style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+        style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}
+      >
         <Text style={{ fontSize: 18, fontWeight: 600, color: '#546e9e' }}>
           Mask:{' '}
         </Text>
@@ -64,10 +65,10 @@ const TextInputDemo1 = () => {
   const [maskTest, maskValue] = useState('');
   const a = () => {
     mask('+1 ([000]) [000] [00] [00]', '13343468815', true)
-      .then(res => {
+      .then((res) => {
         maskValue(res);
       })
-      .catch(err => {
+      .catch((err) => {
         console.log('error', err);
       });
   };
@@ -75,10 +76,10 @@ const TextInputDemo1 = () => {
   const [unmaskTest, unmaskValue] = useState('');
   const b = () => {
     unmask('+1 ([000]) [000] [00] [00]', '+1 334 346 88 15', true)
-      .then(res => {
+      .then((res) => {
         unmaskValue(res);
       })
-      .catch(err => {
+      .catch((err) => {
         console.log('error', err);
       });
   };
@@ -110,31 +111,31 @@ const TextInputDemo1 = () => {
     maskValue: string;
     result: string;
   }[] = [
-      {
-        label: 'Phone numbers',
-        mask: '+86 ([000]) [0000] [0000]',
-        maskValue: '18271959655',
-        result: '+86 (182) 7195 9655',
-      },
-      {
-        label: 'Dates',
-        mask: '[00]{.}[00]{.}[9900]',
-        maskValue: '10242024',
-        result: '10.24.2024',
-      },
-      {
-        label: 'Serial numbers',
-        mask: '[AA]-[00000099]',
-        maskValue: 'CH12345678',
-        result: 'CH-12345678',
-      },
-      {
-        label: 'IPv4',
-        mask: '[099]{.}[099]{.}[099]{.}[099]',
-        maskValue: '19216811',
-        result: '192.168.11',
-      },
-    ];
+    {
+      label: 'Phone numbers',
+      mask: '+86 ([000]) [0000] [0000]',
+      maskValue: '18271959655',
+      result: '+86 (182) 7195 9655',
+    },
+    {
+      label: 'Dates',
+      mask: '[00]{.}[00]{.}[9900]',
+      maskValue: '10242024',
+      result: '10.24.2024',
+    },
+    {
+      label: 'Serial numbers',
+      mask: '[AA]-[00000099]',
+      maskValue: 'CH12345678',
+      result: 'CH-12345678',
+    },
+    {
+      label: 'IPv4',
+      mask: '[099]{.}[099]{.}[099]{.}[099]',
+      maskValue: '19216811',
+      result: '192.168.11',
+    },
+  ];
 
   const [mList, setMList] = useState(maskList);
 
@@ -162,45 +163,87 @@ const TextInputDemo1 = () => {
         explain={
           <>
             <Text>
-              customNotations: (character: s , characterSet : $@ ,
-              isOptional: true)
+              customNotations: (character: s , characterSet : $@ , isOptional:
+              true)
             </Text>
           </>
         }
         mask={'[ss] [9999]'}
         customNotations={[
           { character: 's', characterSet: '$@&', isOptional: true },
-        ]}></BasicTextInputMaskDemo>
+        ]}
+      ></BasicTextInputMaskDemo>
 
       <BasicTextInputMaskDemo
         explain={
           <>
             <Text>
-              customNotations: (character: s , characterSet : $@ ,
-              isOptional: false)
+              customNotations: (character: s , characterSet : $@ , isOptional:
+              false)
             </Text>
           </>
         }
         mask={'[ss] [9999]'}
         customNotations={[
           { character: 's', characterSet: '$@&', isOptional: false },
-        ]}></BasicTextInputMaskDemo>
+        ]}
+      ></BasicTextInputMaskDemo>
+      {/* Affinity calculation strategy */}
+
+      <BasicTextInputMaskDemo
+        showExtractedValue={true}
+        mask={'[00].[00]'}
+        affinityCalculationStrategy="WHOLE_STRING"
+      ></BasicTextInputMaskDemo>
+
+      <BasicTextInputMaskDemo
+        affineFormats={['8 [000] [000]']}
+        showExtractedValue={true}
+        mask={'+7 [000] [000]'}
+        affinityCalculationStrategy="PREFIX"
+      ></BasicTextInputMaskDemo>
+
+      <BasicTextInputMaskDemo
+        affineFormats={['[00]-[000]', '[00]-[00000]']}
+        showExtractedValue={true}
+        mask={'[00]-[0]'}
+        affinityCalculationStrategy="CAPACITY"
+      ></BasicTextInputMaskDemo>
+
+      <BasicTextInputMaskDemo
+        affineFormats={['[00]-[000]', '[00]-[00000]']}
+        showExtractedValue={true}
+        mask={'[00]-[0]'}
+        affinityCalculationStrategy="EXTRACTED_VALUE_CAPACITY"
+      ></BasicTextInputMaskDemo>
+
+      <BasicTextInputMaskDemo
+        autoskip={true}
+        mask={'+86 [aaaa].[aaa]'}
+      ></BasicTextInputMaskDemo>
+
+      <BasicTextInputMaskDemo
+        autoskip={false}
+        mask={'+86 [aaaa].[aaa]'}
+      ></BasicTextInputMaskDemo>
 
       <BasicTextInputMaskDemo
         mask={'+86 [000] [0000] [0000]'}
-        rightToLeft={true}></BasicTextInputMaskDemo>
+        rightToLeft={true}
+      ></BasicTextInputMaskDemo>
 
       <BasicTextInputMaskDemo
         showExtractedValue={true}
         mask={'+86 [000] [0000] [0000]'}
-        rightToLeft={false}></BasicTextInputMaskDemo>
+        rightToLeft={false}
+      ></BasicTextInputMaskDemo>
 
       <BasicTextInputMaskDemo
         showExtractedValue={true}
-        affineFormats={["+7 ([000]) [000] [00] [00]#[900]"]}
+        affineFormats={['+7 ([000]) [000] [00] [00]#[900]']}
         mask={'+7 ([000]) [000] [00] [00]'}
-        rightToLeft={false}></BasicTextInputMaskDemo>
-
+        rightToLeft={false}
+      ></BasicTextInputMaskDemo>
     </ScrollView>
   );
 };

--- a/react-native-text-input-mask/tester/TextInputDemo.tsx
+++ b/react-native-text-input-mask/tester/TextInputDemo.tsx
@@ -1,13 +1,13 @@
-import React, {useState} from 'react';
-import {StyleSheet, Text, View, ScrollView, Button} from 'react-native';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, View, ScrollView, Button, TextInput, findNodeHandle } from 'react-native';
 import TextInputMask, {
   mask,
   unmask,
   setMask,
   TextInputMaskProps,
 } from 'react-native-text-input-mask';
-import {Colors} from 'react-native/Libraries/NewAppScreen';
-import {Tester, TestSuite, TestCase} from '@rnoh/testerino';
+import { Colors } from 'react-native/Libraries/NewAppScreen';
+import { Tester, TestSuite, TestCase } from '@rnoh/testerino';
 
 interface OtherControlProps {
   showExtractedValue?: boolean;
@@ -33,11 +33,11 @@ const BasicTextInputMaskDemo: React.FC<
   return (
     <View style={styles.container}>
       <View
-        style={{display: 'flex', flexDirection: 'row', alignItems: 'center'}}>
-        <Text style={{fontSize: 18, fontWeight: 600, color: '#546e9e'}}>
+        style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+        <Text style={{ fontSize: 18, fontWeight: 600, color: '#546e9e' }}>
           Mask:{' '}
         </Text>
-        <Text style={{fontSize: 16, fontWeight: 600}}>{props.mask}</Text>
+        <Text style={{ fontSize: 16, fontWeight: 600 }}>{props.mask}</Text>
       </View>
 
       {props.explain && props.explain}
@@ -48,7 +48,7 @@ const BasicTextInputMaskDemo: React.FC<
         style={styles.input}
         autoComplete="nickname"
         customNotations={[
-          {character: 's', characterSet: '$@', isOptional: false},
+          { character: 's', characterSet: '$@', isOptional: false },
         ]}
         mask={'[ss] [9999]'}
         {...props}
@@ -62,6 +62,7 @@ const BasicTextInputMaskDemo: React.FC<
 };
 
 const TextInputDemo = () => {
+  const textInputRef = useRef<TextInput>(null);
   const [maskTest, maskValue] = useState('');
   const a = () => {
     mask('+1 ([000]) [000] [00] [00]', '13343468815', true)
@@ -86,11 +87,15 @@ const TextInputDemo = () => {
 
   const [setmaskTest, setmaskValue] = useState('');
   const c = () => {
-    setMask(1, '+1 334 346 88 15', {
-      autocomplete: true,
-      autoskip: true,
-      rightToLeft: true,
-    });
+    const nodeId = findNodeHandle(textInputRef.current);
+    if (nodeId) {
+      setMask(nodeId, '+1 334 346 88 15', {
+        autocomplete: true,
+        autoskip: true,
+        rightToLeft: true,
+      });
+    }
+
   };
   const [onChangeTextTest_formatted, setonChangeTextValue_formatted] =
     useState('');
@@ -111,88 +116,88 @@ const TextInputDemo = () => {
     maskValue: string;
     result: string;
   }[] = [
-    {
-      label: 'Phone numbers',
-      mask: '+86 ([000]) [0000] [0000]',
-      maskValue: '18271959655',
-      result: '+86 (182) 7195 9655',
-    },
-    {
-      label: 'Dates',
-      mask: '[00]{.}[00]{.}[9900]',
-      maskValue: '10242024',
-      result: '10.24.2024',
-    },
-    {
-      label: 'Serial numbers',
-      mask: '[AA]-[00000099]',
-      maskValue: 'CH12345678',
-      result: 'CH-12345678',
-    },
-    {
-      label: 'IPv4',
-      mask: '[099]{.}[099]{.}[099]{.}[099]',
-      maskValue: '19216811',
-      result: '192.168.11',
-    },
-  ];
+      {
+        label: 'Phone numbers',
+        mask: '+86 ([000]) [0000] [0000]',
+        maskValue: '18271959655',
+        result: '+86 (182) 7195 9655',
+      },
+      {
+        label: 'Dates',
+        mask: '[00]{.}[00]{.}[9900]',
+        maskValue: '10242024',
+        result: '10.24.2024',
+      },
+      {
+        label: 'Serial numbers',
+        mask: '[AA]-[00000099]',
+        maskValue: 'CH12345678',
+        result: 'CH-12345678',
+      },
+      {
+        label: 'IPv4',
+        mask: '[099]{.}[099]{.}[099]{.}[099]',
+        maskValue: '19216811',
+        result: '192.168.11',
+      },
+    ];
 
   const [mList, setMList] = useState(maskList);
 
   return (
     <ScrollView>
-      <Tester style={{marginBottom: 400}}>
+      <Tester style={{ marginBottom: 400 }}>
         <TestSuite name="Mask">
           {mList.map((m, index) => (
-            
-              <TestCase key={m.label}
-                itShould={'mask: ' + m.label}
-                tags={['C_API']}
-                initialState={''}
-                arrange={({setState}) => {
-                  return (
-                    <View style={styles.container} key={m.label}>
-                      <View
-                        style={styles.flexRow}>
-                        <Text
-                          style={styles.textSt}>
-                          Mask:{' '}
-                        </Text>
-                        <Text style={{fontSize: 16, fontWeight: 600}}>
-                          {m.mask}
-                        </Text>
-                      </View>
-                      <View
-                        style={styles.flexRow}>
-                        <Text
-                          style={styles.textSt}>
-                          MaskValue:{' '}
-                        </Text>
-                        <Text style={{fontSize: 16, fontWeight: 600}}>
-                          {m.maskValue}
-                        </Text>
-                      </View>
-                      <Button
-                        title="mask"
-                        onPress={() => {
-                          mask(m.mask, m.maskValue, true)
-                            .then(res => {
-                              console.log(res);
-                              setState(res);
-                            })
-                            .catch(err => {
-                              console.log('error', err);
-                            });
-                        }}
-                      />
-                      <Text style={styles.input}>{m.result}</Text>
+
+            <TestCase key={m.label}
+              itShould={'mask: ' + m.label}
+              tags={['C_API']}
+              initialState={''}
+              arrange={({ setState }) => {
+                return (
+                  <View style={styles.container} key={m.label}>
+                    <View
+                      style={styles.flexRow}>
+                      <Text
+                        style={styles.textSt}>
+                        Mask:{' '}
+                      </Text>
+                      <Text style={{ fontSize: 16, fontWeight: 600 }}>
+                        {m.mask}
+                      </Text>
                     </View>
-                  );
-                }}
-                assert={({expect, state}) => {
-                  expect(state).to.be.eq(m.result);
-                }}></TestCase>
-        
+                    <View
+                      style={styles.flexRow}>
+                      <Text
+                        style={styles.textSt}>
+                        MaskValue:{' '}
+                      </Text>
+                      <Text style={{ fontSize: 16, fontWeight: 600 }}>
+                        {m.maskValue}
+                      </Text>
+                    </View>
+                    <Button
+                      title="mask"
+                      onPress={() => {
+                        mask(m.mask, m.maskValue, true)
+                          .then(res => {
+                            console.log(res);
+                            setState(res);
+                          })
+                          .catch(err => {
+                            console.log('error', err);
+                          });
+                      }}
+                    />
+                    <Text style={styles.input}>{m.result}</Text>
+                  </View>
+                );
+              }}
+              assert={({ expect, state }) => {
+                expect(state).to.be.eq(m.result);
+              }}></TestCase>
+
           ))}
           <TestCase itShould="mask: ">
             <View style={styles.container}>
@@ -214,6 +219,7 @@ const TextInputDemo = () => {
             <View style={styles.container}>
               <Text style={styles.label}>Phone Number:</Text>
               <Button title="setmask" onPress={c} />
+              <TextInput style={{ width: "100%", height: "50", borderColor: "black", borderWidth: 1 }} ref={textInputRef}></TextInput>
             </View>
           </TestCase>
         </TestSuite>
@@ -224,14 +230,14 @@ const TextInputDemo = () => {
                 explain={
                   <>
                     <Text>
-                      customNotations: (character: s , characterSet : $@ ,
+                      customNotations: (character: s , characterSet : $@& ,
                       isOptional: true)
                     </Text>
                   </>
                 }
                 mask={'[ss] [9999]'}
                 customNotations={[
-                  {character: 's', characterSet: '$@&', isOptional: true},
+                  { character: 's', characterSet: '$@&', isOptional: true },
                 ]}></BasicTextInputMaskDemo>
             </TestCase>
 
@@ -240,14 +246,14 @@ const TextInputDemo = () => {
                 explain={
                   <>
                     <Text>
-                      customNotations: (character: s , characterSet : $@ ,
+                      customNotations: (character: s , characterSet : $@& ,
                       isOptional: false)
                     </Text>
                   </>
                 }
                 mask={'[ss] [9999]'}
                 customNotations={[
-                  {character: 's', characterSet: '$@&', isOptional: false},
+                  { character: 's', characterSet: '$@&', isOptional: false },
                 ]}></BasicTextInputMaskDemo>
             </TestCase>
 
@@ -264,28 +270,115 @@ const TextInputDemo = () => {
                   mask={'+86 [000] [0000] [0000]'}
                   rightToLeft={false}></BasicTextInputMaskDemo>
               </TestCase>
-
-              <TestCase itShould="rightToLeft: false affineFormats">
+            </TestSuite>
+            <TestSuite name="affineFormats">
+              <TestCase itShould="mask +7 ([000]) [000] [00] [00] affineFormats +7 ([000]) [000] [00] [00]#[900]">
                 <BasicTextInputMaskDemo
                   showExtractedValue={true}
-                  affineFormats = {["+7 ([000]) [000] [00] [00]#[900]"]}
+                  affineFormats={["+7 ([000]) [000] [00] [00]#[900]"]}
                   mask={'+7 ([000]) [000] [00] [00]'}
-                  rightToLeft={false}></BasicTextInputMaskDemo>
+                ></BasicTextInputMaskDemo>
               </TestCase>
             </TestSuite>
+            <TestSuite name='Affinity calculation strategy'>
+              {/* Affinity calculation strategy */}
 
-        
+              <TestCase itShould="strategy WHOLE_STRING">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'[00].[00]'}
+                  affinityCalculationStrategy='WHOLE_STRING'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+              <TestCase itShould=" strategy PREFIX +7 [000] [000] affineFormats 8 [000] [000]">
+                <BasicTextInputMaskDemo
+                 affineFormats={["8 [000] [000]"]}
+                  showExtractedValue={true}
+                  mask={'+7 [000] [000]'}
+                  affinityCalculationStrategy='PREFIX'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+              {/* <TestCase itShould=" strategy PREFIX 8 [000] [000]">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'8 [000] [000]'}
+                  affinityCalculationStrategy='PREFIX'
+                ></BasicTextInputMaskDemo>
+              </TestCase> */}
+
+              <TestCase itShould="strategy CAPACITY mask [00]-[0] affineFormats [00]-[000] / [00]-[00000]">
+                <BasicTextInputMaskDemo
+                  affineFormats={["[00]-[000]","[00]-[00000]"]}
+                  showExtractedValue={true}
+                  mask={'[00]-[0]'}
+                  affinityCalculationStrategy='CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+
+              {/* <TestCase itShould="strategy CAPACITY">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'[00]-[000]'}
+                  affinityCalculationStrategy='CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+              <TestCase itShould="strategy CAPACITY">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'[00]-[00000]'}
+                  affinityCalculationStrategy='CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase> */}
+
+
+              <TestCase itShould="strategy EXTRACTED_VALUE_CAPACITY mask [00]-[0] affineFormats  [00]-[000] / [00]-[00000]">
+                <BasicTextInputMaskDemo
+                affineFormats={["[00]-[000]","[00]-[00000]"]}
+                  showExtractedValue={true}
+                  mask={'[00]-[0]'}
+                  affinityCalculationStrategy='EXTRACTED_VALUE_CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+
+              {/* <TestCase itShould="strategy EXTRACTED_VALUE_CAPACITY">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'[00]-[000]'}
+                  affinityCalculationStrategy='EXTRACTED_VALUE_CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase>
+              <TestCase itShould="strategy EXTRACTED_VALUE_CAPACITY">
+                <BasicTextInputMaskDemo
+                  showExtractedValue={true}
+                  mask={'[00]-[00000]'}
+                  affinityCalculationStrategy='EXTRACTED_VALUE_CAPACITY'
+                ></BasicTextInputMaskDemo>
+              </TestCase> */}
+            </TestSuite>
+
+            <TestSuite name='autoskip'>
+              <TestCase itShould="autoskip: true">
+                <BasicTextInputMaskDemo
+                  autoskip={true}
+                  mask={'+86 [aaaa].[aaa]'}></BasicTextInputMaskDemo>
+              </TestCase>
+              <TestCase itShould="autoskip: false">
+                <BasicTextInputMaskDemo
+                  autoskip={false}
+                  mask={'+86 [aaaa].[aaa]'}></BasicTextInputMaskDemo>
+              </TestCase>
+            </TestSuite>
             <TestSuite name="autoComplete (是否自动补充） ">
               <TestCase itShould="autoComplete: true">
                 <BasicTextInputMaskDemo
                   autocomplete={true}
-                  mask={'+86 [aaaa]'}></BasicTextInputMaskDemo>
+                  mask={'+86 [aaaa].[aaa]'}></BasicTextInputMaskDemo>
               </TestCase>
 
               <TestCase itShould="autoComplete: false">
                 <BasicTextInputMaskDemo
                   autocomplete={false}
-                  mask={'+86 [aaaa]'}></BasicTextInputMaskDemo>
+                  mask={'+86 [aaaa].[aaa]'}></BasicTextInputMaskDemo>
               </TestCase>
             </TestSuite>
           </TestSuite>
@@ -295,16 +388,16 @@ const TextInputDemo = () => {
   );
 };
 const styles = StyleSheet.create({
-    flexRow: {
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-    },
-    textSt: {
-        fontSize: 18,
-        fontWeight: 600,
-        color: '#546e9e',
-    },
+  flexRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textSt: {
+    fontSize: 18,
+    fontWeight: 600,
+    color: '#546e9e',
+  },
   container: {
     flex: 1,
     justifyContent: 'center',


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。 -->

# Summary
close: #1440 
请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增affinityCalculationStrategy和autoskip用例


## Test Plan
新增日志输出不同affinityCalculationStrategy计算亲和度值，如下图：

![20241029-142603(WeLinkPC)](https://github.com/user-attachments/assets/0cde7db9-3f4b-46d9-88aa-91ab0628007d)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
