### PR TITLE
test: 新增透明都0.5的用例

### DIFF
--- a/react-native-image-marker/ImageMarker.tsx
+++ b/react-native-image-marker/ImageMarker.tsx
@@ -35,8 +35,10 @@ export const ImageMarker = () => {
   const [url_backscale1_5, seturl_backscale1_5] = useState('');
   // image alpha
   const [url_alpha0_1, seturl_alpha0_1] = useState('');
+  const [url_alpha0_5, seturl_alpha0_5] = useState('');
   const [url_alpha1, seturl_alpha1] = useState('');
   const [url_backalpha0_1, seturl_backalpha0_1] = useState('');
+  const [url_backalpha0_5, seturl_backalpha0_5] = useState('');
   const [url_backalpha1, seturl_backalpha1] = useState('');
   // image position
   const [url_icon_topLeft, seturl_icon_topLeft] = useState('');
@@ -139,6 +141,14 @@ export const ImageMarker = () => {
     }
     ]
   }
+  const image_options_alpha0_5: ImageMarkOptions = {
+    backgroundImage: { src: require('./assets/code-images/1.png') },
+    watermarkImages: [{
+      src: require('./assets/pravatar-131.jpg'),
+      alpha: 0.5
+    }
+    ]
+  }
   const image_options_alpha1: ImageMarkOptions = {
     backgroundImage: { src: require('./assets/code-images/1.png') },
     watermarkImages: [{
@@ -151,6 +161,16 @@ export const ImageMarker = () => {
     backgroundImage: {
       src: require('./assets/code-images/1.png'),
       alpha: 0.1
+    },
+    watermarkImages: [{
+      src: require('./assets/pravatar-131.jpg')
+    }
+    ]
+  }
+  const image_options_backalpha0_5: ImageMarkOptions = {
+    backgroundImage: {
+      src: require('./assets/code-images/1.png'),
+      alpha: 0.5
     },
     watermarkImages: [{
       src: require('./assets/pravatar-131.jpg')
@@ -426,6 +446,13 @@ export const ImageMarker = () => {
       console.log('error', error)
     })
   }
+  const markImagealpha0_5 = () => {
+    Marker.markImage(image_options_alpha0_5).then((result) => {
+      seturl_alpha0_5(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
   const markImagealpha1 = () => {
     Marker.markImage(image_options_alpha1).then((result) => {
       seturl_alpha1(result)
@@ -436,6 +463,13 @@ export const ImageMarker = () => {
   const markImagebackalpha0_1 = () => {
     Marker.markImage(image_options_backalpha0_1).then((result) => {
       seturl_backalpha0_1(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
+  const markImagebackalpha0_5 = () => {
+    Marker.markImage(image_options_backalpha0_5).then((result) => {
+      seturl_backalpha0_5(result)
     }).catch(error => {
       console.log('error', error)
     })
@@ -537,6 +571,7 @@ export const ImageMarker = () => {
   const [url_text_textalain_right, seturl_text_textalain_right] = useState('');
   // image alpha
   const [url_backalpha0_1_text, seturl_backalpha0_1_text] = useState('');
+  const [url_backalpha0_5_text, seturl_backalpha0_5_text] = useState('');
   const [url_backalpha1_text, seturl_backalpha1_text] = useState('');
   // text position
   const [url_text_topLeft, seturl_text_topLeft] = useState('');
@@ -1773,6 +1808,13 @@ export const ImageMarker = () => {
       console.log('error', error)
     })
   }
+  const markTextbackalpha0_5 = () => {
+    Marker.markText(text_options_backalpha0_5).then((result) => {
+      seturl_backalpha0_5_text(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
   const markTextbackalpha1 = () => {
     Marker.markText(text_options_backalpha1).then((result) => {
       seturl_backalpha1_text(result)
@@ -2069,6 +2111,26 @@ export const ImageMarker = () => {
             </View>
           </TestCase>
           <TestCase
+            itShould=' back_alpha0_5'
+            tags={['C_API']}>
+            <View style={styles.body}>
+              <View style={styles.sectionContainer}>
+                <Text style={styles.sectionTitle}>
+                  {"image marker"}
+                </Text>
+                <Button
+                  title="back_alpha0_5"
+                  color="#9a73ef"
+                  onPress={markImagebackalpha0_5}
+                />
+                <Text style={styles.sectionTitle}>
+                  {url_backalpha0_5}
+                </Text>
+                <Image resizeMode='contain' source={{ uri: url_backalpha0_5, width: 300, height: 150 }} />
+              </View>
+            </View>
+          </TestCase>
+          <TestCase
             itShould=' back_alpha1'
             tags={['C_API']}>
             <View style={styles.body}>
@@ -2105,6 +2167,26 @@ export const ImageMarker = () => {
                   {url_alpha0_1}
                 </Text>
                 <Image resizeMode='contain' source={{ uri: url_alpha0_1, width: 300, height: 150 }} />
+              </View>
+            </View>
+          </TestCase>
+          <TestCase
+            itShould=' icon_alpha0_5 '
+            tags={['C_API']}>
+            <View style={styles.body}>
+              <View style={styles.sectionContainer}>
+                <Text style={styles.sectionTitle}>
+                  {"image marker"}
+                </Text>
+                <Button
+                  title="icon_alpha0_5 "
+                  color="#9a73ef"
+                  onPress={markImagealpha0_5}
+                />
+                <Text style={styles.sectionTitle}>
+                  {url_alpha0_5}
+                </Text>
+                <Image resizeMode='contain' source={{ uri: url_alpha0_5, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -3432,6 +3514,26 @@ export const ImageMarker = () => {
                   {url_backalpha0_1_text}
                 </Text>
                 <Image resizeMode='contain' source={{ uri: url_backalpha0_1_text, width: 300, height: 150 }} />
+              </View>
+            </View>
+          </TestCase>
+          <TestCase
+            itShould=' back_alpha0_5 '
+            tags={['C_API']}>
+            <View style={styles.body}>
+              <View style={styles.sectionContainer}>
+                <Text style={styles.sectionTitle}>
+                  {"image marker"}
+                </Text>
+                <Button
+                  title="back_alpha0_5 "
+                  color="#9a73ef"
+                  onPress={markTextbackalpha0_5}
+                />
+                <Text style={styles.sectionTitle}>
+                  {url_backalpha0_5_text}
+                </Text>
+                <Image resizeMode='contain' source={{ uri: url_backalpha0_5_text, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>

--- a/react-native-image-marker/ImageMarkerNomal.tsx
+++ b/react-native-image-marker/ImageMarkerNomal.tsx
@@ -30,8 +30,10 @@ export const ImageMarkerNomal = () => {
   const [url_backscale1_5, seturl_backscale1_5] = useState('');
   // image alpha
   const [url_alpha0_1, seturl_alpha0_1] = useState('');
+  const [url_alpha0_5, seturl_alpha0_5] = useState('');
   const [url_alpha1, seturl_alpha1] = useState('');
   const [url_backalpha0_1, seturl_backalpha0_1] = useState('');
+  const [url_backalpha0_5, seturl_backalpha0_5] = useState('');
   const [url_backalpha1, seturl_backalpha1] = useState('');
   // image position
   const [url_icon_topLeft, seturl_icon_topLeft] = useState('');
@@ -134,6 +136,14 @@ export const ImageMarkerNomal = () => {
     }
     ]
   }
+  const image_options_alpha0_5: ImageMarkOptions = {
+    backgroundImage: { src: require('./assets/code-images/1.png') },
+    watermarkImages: [{
+      src: require('./assets/pravatar-131.jpg'),
+      alpha: 0.5
+    }
+    ]
+  }
   const image_options_alpha1: ImageMarkOptions = {
     backgroundImage: { src: require('./assets/code-images/1.png') },
     watermarkImages: [{
@@ -146,6 +156,16 @@ export const ImageMarkerNomal = () => {
     backgroundImage: {
       src: require('./assets/code-images/1.png'),
       alpha: 0.1
+    },
+    watermarkImages: [{
+      src: require('./assets/pravatar-131.jpg')
+    }
+    ]
+  }
+  const image_options_backalpha0_5: ImageMarkOptions = {
+    backgroundImage: {
+      src: require('./assets/code-images/1.png'),
+      alpha: 0.5
     },
     watermarkImages: [{
       src: require('./assets/pravatar-131.jpg')
@@ -421,6 +441,13 @@ export const ImageMarkerNomal = () => {
       console.log('error', error)
     })
   }
+  const markImagealpha0_5 = () => {
+    Marker.markImage(image_options_alpha0_5).then((result) => {
+      seturl_alpha0_5(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
   const markImagealpha1 = () => {
     Marker.markImage(image_options_alpha1).then((result) => {
       seturl_alpha1(result)
@@ -431,6 +458,13 @@ export const ImageMarkerNomal = () => {
   const markImagebackalpha0_1 = () => {
     Marker.markImage(image_options_backalpha0_1).then((result) => {
       seturl_backalpha0_1(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
+  const markImagebackalpha0_5 = () => {
+    Marker.markImage(image_options_backalpha0_5).then((result) => {
+      seturl_backalpha0_5(result)
     }).catch(error => {
       console.log('error', error)
     })
@@ -532,6 +566,7 @@ export const ImageMarkerNomal = () => {
   const [url_text_textalain_right, seturl_text_textalain_right] = useState('');
   // image alpha
   const [url_backalpha0_1_text, seturl_backalpha0_1_text] = useState('');
+  const [url_backalpha0_5_text, seturl_backalpha0_5_text] = useState('');
   const [url_backalpha1_text, seturl_backalpha1_text] = useState('');
   // text position
   const [url_text_topLeft, seturl_text_topLeft] = useState('');
@@ -1267,6 +1302,17 @@ export const ImageMarkerNomal = () => {
     }
     ]
   }
+  const text_options_backalpha0_5: TextMarkOptions = {
+    backgroundImage: {
+      src: require('./assets/code-images/1.png'),
+      alpha: 1
+    },
+    watermarkTexts: [{
+      text: 'test text',
+      style: { color: '#FFFF00', fontSize: 100, }
+    }
+    ]
+  }
   const text_options_backalpha1: TextMarkOptions = {
     backgroundImage: {
       src: require('./assets/code-images/1.png'),
@@ -1768,6 +1814,13 @@ export const ImageMarkerNomal = () => {
       console.log('error', error)
     })
   }
+  const markTextbackalpha0_5 = () => {
+    Marker.markText(text_options_backalpha0_5).then((result) => {
+      seturl_backalpha0_5_text(result)
+    }).catch(error => {
+      console.log('error', error)
+    })
+  }
   const markTextbackalpha1 = () => {
     Marker.markText(text_options_backalpha1).then((result) => {
       seturl_backalpha1_text(result)
@@ -2026,7 +2079,22 @@ export const ImageMarkerNomal = () => {
           <Image resizeMode='contain' source={{ uri: url_backalpha0_1, width: 300, height: 150 }} />
         </View>
       </View>
-
+      <View style={styles.body}>
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>
+            {"image marker"}
+          </Text>
+          <Button
+            title="back_alpha0_5 "
+            color="#9a73ef"
+            onPress={markImagebackalpha0_5}
+          />
+          <Text style={styles.sectionTitle}>
+            {url_backalpha0_5}
+          </Text>
+          <Image resizeMode='contain' source={{ uri: url_backalpha0_5, width: 300, height: 150 }} />
+        </View>
+      </View>
       <View style={styles.body}>
         <View style={styles.sectionContainer}>
           <Text style={styles.sectionTitle}>
@@ -2060,7 +2128,22 @@ export const ImageMarkerNomal = () => {
           <Image resizeMode='contain' source={{ uri: url_alpha0_1, width: 300, height: 150 }} />
         </View>
       </View>
-
+      <View style={styles.body}>
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>
+            {"image marker"}
+          </Text>
+          <Button
+            title="icon_alpha0_5"
+            color="#9a73ef"
+            onPress={markImagealpha0_5}
+          />
+          <Text style={styles.sectionTitle}>
+            {url_alpha0_5}
+          </Text>
+          <Image resizeMode='contain' source={{ uri: url_alpha0_5, width: 300, height: 150 }} />
+        </View>
+      </View>
       <View style={styles.body}>
         <View style={styles.sectionContainer}>
           <Text style={styles.sectionTitle}>
@@ -3183,7 +3266,22 @@ export const ImageMarkerNomal = () => {
           <Image resizeMode='contain' source={{ uri: url_backalpha0_1_text, width: 300, height: 150 }} />
         </View>
       </View>
-
+      <View style={styles.body}>
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>
+            {"image marker"}
+          </Text>
+          <Button
+            title="back_alpha0_5 "
+            color="#9a73ef"
+            onPress={markTextbackalpha0_5}
+          />
+          <Text style={styles.sectionTitle}>
+            {url_backalpha0_5_text}
+          </Text>
+          <Image resizeMode='contain' source={{ uri: url_backalpha0_5_text, width: 300, height: 150 }} />
+        </View>
+      </View>
       <View style={styles.body}>
         <View style={styles.sectionContainer}>
           <Text style={styles.sectionTitle}>


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。 -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增透明度0.5的用例

## Test Plan
背景图片透明度0.5：

![image_back_0_5](https://github.com/user-attachments/assets/82a52dae-ec08-4157-a680-fd93dd9356fb)

图标透明度0.5：

![image_icon_0_5](https://github.com/user-attachments/assets/4d464773-1455-4189-ad7f-44b1221a1684)

文字水印背景透明度0.5：

![text_back_0_5](https://github.com/user-attachments/assets/e539eb88-fab4-40f9-a08f-75b514d69eee)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
