### PR TITLE
test: 修改rn-sliding-up-panel测试用例

### DIFF
--- a/rn-sliding-up-panel/page/OnBottomReached.tsx
+++ b/rn-sliding-up-panel/page/OnBottomReached.tsx
@@ -37,7 +37,7 @@ export function OnBottomReached() {
         animatedValue={_draggedValue}
         draggableRange={draggableRange}
         snappingPoints={[300]}
-        onMomentumDragStart={() => {
+        onBottomReached={() => {
           setEventBackText({ ...eventBackText, onBottomReached: 'bottomReached change text' });
         }}>
         <View style={styles.panel}>

--- a/rn-sliding-up-panel/page/OnMomentumDragEnd.tsx
+++ b/rn-sliding-up-panel/page/OnMomentumDragEnd.tsx
@@ -37,7 +37,7 @@ export function OnMomentumDragEnd() {
         animatedValue={_draggedValue}
         draggableRange={draggableRange}
         snappingPoints={[300]}
-        onMomentumDragStart={() => {
+        onMomentumDragEnd={() => {
           setEventBackText({ ...eventBackText, onMomentumDragEnd: 'momentumDragEnd change text' });
         }}>
         <View style={styles.panel}>


### PR DESCRIPTION
# Summary

修改rn-sliding-up-panel测试用例，修改onBottomReached、onMomentumDragEnd部分代码错误

## Checklist

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
