### PR TITLE
test: 修改react-native-image-marker 缩放用例 图片显示由resizeMode='contain' 改为resizeMode='center'

### DIFF
--- a/react-native-image-marker/ImageMarker.tsx
+++ b/react-native-image-marker/ImageMarker.tsx
@@ -2309,7 +2309,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_backscale0_5}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_backscale0_5, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_backscale0_5, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -2329,7 +2329,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_backscale1_5}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_backscale1_5, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_backscale1_5, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -2349,7 +2349,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_scale0_5}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_scale0_5, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_scale0_5, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -2369,7 +2369,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_scale1_5}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_scale1_5, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_scale1_5, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -3716,7 +3716,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_backscale0_5_text}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_backscale0_5_text, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_backscale0_5_text, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>
@@ -3736,7 +3736,7 @@ export const ImageMarker = () => {
                 <Text style={styles.sectionTitle}>
                   {url_backscale1_5_text}
                 </Text>
-                <Image resizeMode='contain' source={{ uri: url_backscale1_5_text, width: 300, height: 150 }} />
+                <Image resizeMode='center' source={{ uri: url_backscale1_5_text, width: 300, height: 150 }} />
               </View>
             </View>
           </TestCase>


### PR DESCRIPTION
# Summary

- 修改react-native-image-marker 缩放用例 图片显示由resizeMode='contain' 改为resizeMode='center'，close: #1612 


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 更新了 JS/TS 代码 (如有)
