### PR TITLE
test: 修改react-native-material-dropdown测试用例

### DIFF
--- a/react-native-material-dropdown/test/DropDownTest.tsx
+++ b/react-native-material-dropdown/test/DropDownTest.tsx
@@ -478,6 +478,24 @@ export class DropDownTest extends Component {
                 </TestSuite>
 
                 <TestSuite name="DropDown测试case">
+                  <TestCase itShould="Props:renderAccessory 属性测试,需要指定renderRightAccessory或者renderLeftAccessory">
+                    <View style={styles.container}>
+                      <Dropdown
+                        value={typography}
+                        data={typographyData}
+                        dropdownPosition={0}
+                        dropdownOffset={{ top: 10, left: 0, }}
+                        pickerStyle={{}}
+                        renderLeftAccessory={() => <View style={{ width: 30, borderWidth: 0.5 }}>
+                          <Image source={{ uri: 'https://pics1.baidu.com/feed/c2cec3fdfc0392456576003568f8f3cc7c1e2540.jpeg@f_auto?token=b8c70f853c3c1bd7984b47a2e382552a' }}
+                            style={{ width: 30, height: 30}} />
+                        </View>}
+                      />
+                    </View>
+                  </TestCase>
+                </TestSuite>
+
+                <TestSuite name="DropDown测试case">
                   <TestCase itShould="Props:renderBase 自定义下拉菜单的基础属性">
                     <View style={styles.container}>
                       <Dropdown


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响-->
请解释此次更改的 **动机**，以下是一些帮助您的要点
- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
这个PR不涉及到issues
- 这个功能是什么？（如果适用）
修改react-native-material-dropdown测试用例
- 您是如何实现解决方案的？
按照要求修改测试demo用例
- 这个更改影响了库的哪些部分？
demo修改，不涉及源库

## Test Plan
展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
使用Mate 60 pro验证ok
demo地址：https://github.com/react-native-oh-library/RNOHDCS/tree/main/react-native-material-dropdown

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->
- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)