### PR TITLE
test:修改ffmpeg-kit三方库demo，新增测试场景

### DIFF
--- a/react-native-ffmpeg-kit/test-app-npm/src/audio-tab.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/audio-tab.js
@@ -117,7 +117,6 @@ export default class AudioTab extends React.Component {
                 extension = "mpg";
                 break;
             case "mp3 (liblame)":
-            case "mp3 (libshine)":
                 extension = "mp3";
                 break;
             case "vorbis":
@@ -125,15 +124,6 @@ export default class AudioTab extends React.Component {
                 break;
             case "opus":
                 extension = "opus";
-                break;
-            case "amr-nb":
-                extension = "amr";
-                break;
-            case "amr-wb":
-                extension = "amr";
-                break;
-            case "ilbc":
-                extension = "lbc";
                 break;
             case "speex":
                 extension = "spx";
@@ -176,6 +166,10 @@ export default class AudioTab extends React.Component {
                 return `-hide_banner -y -i ${audioSampleFile} -c:a libvorbis -b:a 64k ${audioOutputFile}`;
             case "wavpack":
                 return `-hide_banner -y -i ${audioSampleFile} -c:a wavpack -b:a 64k ${audioOutputFile}`;
+            case "opus":
+                return `-hide_banner -y -i ${audioSampleFile} -c:a libopus -b:a 64k -vbr on -compression_level 10 ${audioOutputFile}`;
+            case "speex":
+                return `-hide_banner -y -i ${audioSampleFile} -c:a libspeex -ar 16000 ${audioOutputFile}`;
             default:
 
                 // soxr
@@ -202,6 +196,7 @@ export default class AudioTab extends React.Component {
                         <Picker.Item label="mp3 (liblame)" value="mp3 (liblame)"/>
                         <Picker.Item label="vorbis" value="vorbis"/>
                         <Picker.Item label="wavpack" value="wavpack"/>
+                        <Picker.Item label="opus" value="opus"/>
                     </Picker>
                 </View>
                 <View style={styles.buttonViewStyle}>

--- a/react-native-ffmpeg-kit/test-app-npm/src/main.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/main.js
@@ -88,6 +88,13 @@ function BottomTabs() {
                 }}
             />
             <Tab.Screen
+                name="PIPE"
+                component={PipeTab}
+                options={{
+                    tabBarLabel: 'PIPE'
+                }}
+            />
+            <Tab.Screen
                 name="CONCURRENT EXECUTION"
                 component={ConcurrentExecutionTab}
                 options={{

--- a/react-native-ffmpeg-kit/test-app-npm/src/other-tab.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/other-tab.js
@@ -55,6 +55,9 @@ export default class OtherTab extends React.Component {
             case "chromaprint":
                 this.testChromaprint();
                 break;
+            case "webp":
+                this.testWebp();
+                break;
         }
     }
 
@@ -202,6 +205,7 @@ export default class OtherTab extends React.Component {
                             this.setState({selectedTest: itemValue})
                         }>
                         <Picker.Item label="chromaprint" value="chromaprint"/>
+                        <Picker.Item label="webp" value="webp"/>
                     </Picker>
                 </View>
                 <View style={styles.buttonViewStyle}>

--- a/react-native-ffmpeg-kit/test-app-npm/src/pipe-tab.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/pipe-tab.js
@@ -1,0 +1,155 @@
+import React from 'react';
+import {ScrollView, Text, TouchableOpacity, View} from 'react-native';
+import RNFS from 'react-native-fs';
+import VideoUtil from './video-util';
+import {FFmpegKit, FFmpegKitConfig, ReturnCode} from 'ffmpeg-kit-react-native';
+import {styles} from './style';
+import {ProgressModal} from "./progress_modal";
+import {deleteFile, ffprint, listAllStatistics, notNull} from './util';
+
+export default class PipeTab extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            statistics: undefined,
+            outputText: ''
+        };
+
+        this.progressModalReference = React.createRef();
+    }
+
+    componentDidMount() {
+        this.props.navigation.addListener('focus', (_) => {
+            this.pause();
+            this.clearOutput();
+            this.setActive();
+        });
+    }
+
+    setActive() {
+        ffprint("Pipe Tab Activated");
+        FFmpegKitConfig.enableLogCallback(this.logCallback);
+        FFmpegKitConfig.enableStatisticsCallback(this.statisticsCallback);
+    }
+
+    logCallback = (log) => {
+        ffprint("logCallback: " + log.getMessage());
+        this.appendOutput("logCallback: " + log.getMessage());
+    }
+
+    statisticsCallback = (statistics) => {
+        this.setState({statistics: statistics});
+        this.updateProgressDialog();
+    }
+
+    appendOutput(logMessage) {
+        this.setState({outputText: this.state.outputText + logMessage});
+    };
+
+    clearOutput() {
+        this.setState({outputText: ''});
+    }
+
+    createVideo = () => {
+        let videoFile = this.getVideoFile();
+        FFmpegKitConfig.registerNewFFmpegPipe().then((pipe1) => {
+            this.appendOutput(`pipe1: ${pipe1}\n`);
+            this.appendOutput("管道文件pipe1已经生成，请查看手机目录：/data/storage/el2/base/haps/entry/cache/.cache/ffmpegkit/pipes/fk_pipe_1");
+            FFmpegKitConfig.registerNewFFmpegPipe().then((pipe2) => {
+                this.appendOutput(`pipe2: ${pipe2}\n`);
+                this.appendOutput("管道文件pipe2已经生成，请查看手机目录：/data/storage/el2/base/haps/entry/cache/.cache/ffmpegkit/pipes/fk_pipe_2");
+                FFmpegKitConfig.registerNewFFmpegPipe().then((pipe3) => {
+
+                    // IF VIDEO IS PLAYING STOP PLAYBACK
+                    this.pause();
+                    this.appendOutput(`pipe3: ${pipe3}\n`);
+                    this.appendOutput("管道文件pipe3已经生成，请查看手机目录：/data/storage/el2/base/haps/entry/cache/.cache/ffmpegkit/pipes/fk_pipe_3");
+
+                    deleteFile(videoFile);
+
+                    ffprint("Testing PIPE with 'mpeg4' codec");
+                    FFmpegKitConfig.writeToPipe(VideoUtil.assetPath(VideoUtil.ASSET_1), pipe1);
+                    FFmpegKitConfig.writeToPipe(VideoUtil.assetPath(VideoUtil.ASSET_2), pipe2);
+                    FFmpegKitConfig.writeToPipe(VideoUtil.assetPath(VideoUtil.ASSET_3), pipe3);
+                });
+            });
+        });
+    }
+
+    playVideo() {
+        let player = this.player;
+        if (player !== undefined) {
+            player.seek(0);
+        }
+        this.setState({paused: false});
+    }
+
+    pause() {
+        this.setState({paused: true});
+    }
+
+    getVideoFile() {
+        return `${RNFS.CachesDirectoryPath}/video.mp4`;
+    }
+
+    showProgressDialog() {
+        // CLEAN STATISTICS
+        this.setState({statistics: undefined});
+        this.progressModalReference.current.show(`Creating video`);
+    }
+
+    updateProgressDialog() {
+        let statistics = this.state.statistics;
+        if (statistics === undefined || statistics.getTime() < 0) {
+            return;
+        }
+
+        let timeInMilliseconds = statistics.getTime();
+        let totalVideoDuration = 9000;
+        let completePercentage = Math.round((timeInMilliseconds * 100) / totalVideoDuration);
+        this.progressModalReference.current.update(`Creating video % ${completePercentage}`);
+    }
+
+    hideProgressDialog() {
+        this.progressModalReference.current.hide();
+    }
+
+    onPlayError = (err) => {
+        ffprint('Play error: ' + JSON.stringify(err));
+    }
+
+    render() {
+        return (
+            <View style={styles.screenStyle}>
+                <View style={styles.headerViewStyle}>
+                    <Text
+                        style={styles.headerTextStyle}>
+                        FFmpegKit ReactNative
+                    </Text>
+                </View>
+                <View style={[styles.buttonViewStyle, {paddingTop: 50, paddingBottom: 50}]}>
+                    <TouchableOpacity
+                        style={styles.buttonStyle}
+                        onPress={this.createVideo}>
+                        <Text style={styles.buttonTextStyle}>CREATE</Text>
+                    </TouchableOpacity>
+                </View>
+                <ProgressModal
+                    visible={false}
+                    ref={this.progressModalReference}/>
+                <View style={styles.outputViewStyle}>
+                    <ScrollView
+                        ref={(view) => {
+                            this.scrollViewReference = view;
+                        }}
+                        onContentSizeChange={(width, height) => this.scrollViewReference.scrollTo({y: height})}
+                        style={styles.outputScrollViewStyle}>
+                        <Text style={styles.outputTextStyle}>{this.state.outputText}</Text>
+                    </ScrollView>
+                </View>
+            </View>
+        );
+    }
+
+}

--- a/react-native-ffmpeg-kit/test-app-npm/src/style.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/style.js
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
         borderColor: '#B9C3C7',
         borderRadius: 5,
         borderWidth: 1,
-        height: window.height - 310,
+        height: window.height - 500,
         width: window.width - 40,
         marginVertical: 20,
         marginHorizontal: 20
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
         borderColor: '#B9C3C7',
         borderRadius: 5,
         borderWidth: 1,
-        height: (window.height - 250) / 2,
+        height: (window.height - 300) / 2,
         width: window.width - 40,
         marginVertical: 20,
         marginHorizontal: 20
@@ -82,6 +82,7 @@ const styles = StyleSheet.create({
     outputScrollViewStyle: {
         padding: 4,
         backgroundColor: '#f1c40f',
+        marginBottom: 65,
         borderColor: '#f39c12',
         borderRadius: 5,
         borderWidth: 1

--- a/react-native-ffmpeg-kit/test-app-npm/src/video-tab.js
+++ b/react-native-ffmpeg-kit/test-app-npm/src/video-tab.js
@@ -115,6 +115,9 @@ export default class VideoTab extends React.Component {
             case "x265":
                 videoCodec = "libx265";
                 break;
+            case "openh264":
+                videoCodec = "libopenh264";
+                break;
             case "xvid":
                 videoCodec = "libxvid";
                 break;
@@ -211,6 +214,7 @@ export default class VideoTab extends React.Component {
                     <Picker.Item label="mpeg4" value="mpeg4"/>
                     <Picker.Item label="x264" value="x264"/>
                     <Picker.Item label="x265" value="x265"/>
+                    <Picker.Item label="openh264" value="openh264"/>
                     <Picker.Item label="xvid" value="xvid"/>
                     <Picker.Item label="vp8" value="vp8"/>
                     <Picker.Item label="vp9" value="vp9"/>


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增 opus 测试场景
- 新增 speex 测试场景
- 新增 openh264 测试场景
- 新增 webp 测试场景

## Test Plan

![image](https://github.com/user-attachments/assets/3039a2f6-92df-4d42-9a93-9eb62532264c)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

