### PR TITLE
新增ffmpeg-kit测试属性

### DIFF
--- a/react-native-ffmpeg-kit/concurrent-execution-tab.js
+++ b/react-native-ffmpeg-kit/concurrent-execution-tab.js
@@ -28,7 +28,11 @@ export default class ConcurrentExecutionTab extends React.Component {
 
     async setActive() {
         ffprint("Concurrent Execution Tab Activated");
+        let sessionsCountS = (await FFmpegKitConfig.getSessions()).length;
+        this.setState({testlog:`clearSessions start: ${sessionsCountS}.`});
         await FFmpegKitConfig.clearSessions();
+        let sessionsCountE = (await FFmpegKitConfig.getSessions()).length;
+        this.setState({testlog:this.state.testlog +`clearSessions end: ${sessionsCountE}.`});
 		await FFmpegKitConfig.enableLogs();
         FFmpegKitConfig.enableLogCallback(this.logCallback);
         FFmpegKitConfig.enableStatisticsCallback(undefined);
@@ -57,6 +61,7 @@ export default class ConcurrentExecutionTab extends React.Component {
         let ffmpegCommand = VideoUtil.generateEncodeVideoScript(image1Path, image2Path, image3Path, videoFile, "mpeg4", "");
 
         ffprint(`FFmpeg process starting for button ${buttonNumber} with arguments: \'${ffmpegCommand}\'.`);
+
 
         FFmpegKit.executeAsync(ffmpegCommand, async (session) => {
                 const sessionId = await session.getSessionId();
@@ -89,7 +94,7 @@ export default class ConcurrentExecutionTab extends React.Component {
 
             //listFFmpegSessions();
             FFmpegKit.listSessions().then(sessionList => {
-                this.setState({testlog: `Listing ${sessionList.length} FFmpeg sessions asynchronously.`});
+                this.setState({testlog: `Listing ${sessionList.length} FFmpeg sessions asynchronously.Session id:${sessionList[0].getSessionId()}, startTime:${sessionList[0].getStartTime()}`});
             });
         });
     }


### PR DESCRIPTION
# Summary

- 新增isSuccess属性失败场景。
- 获取ffprobsession中的属性。
- 获取ffmpegsession中的属性。
- 展示clearsession前后的效果。

## Test Plan

![image](https://github.com/user-attachments/assets/51284d77-cac8-49a7-89e3-c5dfcde91927)

## Checklist


- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
