### PR TITLE
test:更改react-native-reanimated动画库支持useAnimatedKeyboard属性能力的demo

### DIFF
--- a/react-native-reanimated/example/AnimatedKeyboardExample.tsx
+++ b/react-native-reanimated/example/AnimatedKeyboardExample.tsx
@@ -2,16 +2,39 @@ import React from 'react';
 import Animated, {
   useAnimatedKeyboard,
   useAnimatedStyle,
+  withTiming,
+  useSharedValue,
+  Easing,
+  withRepeat
 } from '@react-native-oh-tpl/react-native-reanimated';
 import { StyleSheet, TextInput, View, useColorScheme } from 'react-native';
 
 export default function AnimatedKeyboardExample() {
   const colorScheme = useColorScheme();
   const keyboard = useAnimatedKeyboard();
+  const randomWidth = useSharedValue(50);
+  const offset = useSharedValue<number>(100);
+  const config = {
+    duration: 500,
+    easing: Easing.bezierFn(0.5, 0.01, 0, 1),
+  };
   const animatedStyles = useAnimatedStyle(() => ({
     transform: [{ translateY: -keyboard.height.value }],
   }));
+  const animatedStylesOffset = useAnimatedStyle(() => ({
+    transform: [{ translateX: offset.value }],
+  }));
+  const startAnimation = () => {
+    offset.value = withRepeat(
+      withTiming(offset.value > 0 ? 0 : 120, { duration: 1500 }),
+      -1,
+      true
+    );
+  };
 
+  React.useEffect(() => {
+    startAnimation();
+  }, []);
   return (
     <Animated.View
       style={[
@@ -19,6 +42,7 @@ export default function AnimatedKeyboardExample() {
         animatedStyles,
         { backgroundColor: colorScheme === 'light' ? '#fff' : '#000' },
       ]}>
+       <Animated.View style={[styles.box_a, animatedStylesOffset]} />
       <View style={styles.box}>
         <TextInput placeholder="Text Input" />
       </View>
@@ -41,5 +65,11 @@ const styles = StyleSheet.create({
     backgroundColor: '#b58df1',
     borderRadius: 5,
     margin: 20,
+  },
+  box_a: {
+    height: 50,
+    width: 50,
+    backgroundColor: '#00ff00',
+    borderRadius: 20,
   },
 });


### PR DESCRIPTION


# Summary


- test:更改react-native-reanimated动画库支持useAnimatedKeyboard属性能力的demo
- Closed: #1666 

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.72.68-CAPI
- DevEco Studio: 5.0.11.100
- OH SDK: HarmonyOS NEXT 5.0.4.150
- ROM: 5.0.0.150(Canary3)

