### PR TITLE
test:修改ant-design-mobile-rn中demo居中对齐和顶部居中的显示问题

### DIFF
--- a/ant-design-mobile-rn/ListTest.tsx
+++ b/ant-design-mobile-rn/ListTest.tsx
@@ -118,6 +118,7 @@ export default () => {
                 <Brief>辅助文字内容</Brief>
               </View>
             }
+			multipleLine
           >
             顶部对齐
           </Item>
@@ -127,7 +128,7 @@ export default () => {
         <List>
           <Item
             wrap
-            align="top"
+            align="middle"
             extra={
               <View>
                 内容内容


### PR DESCRIPTION
# Summary

- test:修改ant-design-mobile-rn中demo居中对齐和顶部居中的显示问题

## Test Plan
![image](https://github.com/user-attachments/assets/a14962c2-43ab-4619-93e8-ea8b495585b9)



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
