### PR TITLE
test:修复svg 宽度设置过小导致绘制不完全的问题以及解决autocomplete-dropdown数据网络请求异常和正常结果显示

### DIFF
--- a/react-native-svg/tester/svgDemoCases/components/gen.tsx
+++ b/react-native-svg/tester/svgDemoCases/components/gen.tsx
@@ -71,7 +71,7 @@ function RenderCase({_case, basicProps, comName, renderComChildren, bindFunc, no
                             <View
                                 style={{
                                     borderWidth: 1,
-                                    width: 100,
+                                    width: 240,
                                     height: 100
                                 }}
                             >


### PR DESCRIPTION
# Summary

- test:修复svg 宽度设置过小导致绘制不完全的问题以及解决autocomplete-dropdown数据网络请求异常和正常结果显示

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)