### PR TITLE
test: 添加gesture-handler手势库测试场景

### DIFF
--- a/react-native-gesture-handler/App.tsx
+++ b/react-native-gesture-handler/App.tsx
@@ -8,6 +8,7 @@ import Swipeable from './Swipeable';
 import GestureHandlers from './GestureHandlers';
 import Buttons from './Buttons';
 import Touchables from './Touchables';
+import DDGestureDemo from './DDGestureDemo';
 
 const Stack = createStackNavigator();
 
@@ -29,6 +30,9 @@ class Home extends React.Component {
     }
     onPress6 = () => {
         this.props.navigation.navigate('GestureHandlers');
+    }
+    onPress7 = () => {
+        this.props.navigation.navigate('滴滴出行');
     }
 
 
@@ -53,6 +57,9 @@ class Home extends React.Component {
                 <View style={{height:50,marginTop:12}}>
                     <Button title="GestureHandlers"  onPress={this.onPress6}></Button>
                 </View>
+                <View style={{height:50,marginTop:12}}>
+                    <Button title="滴滴出行"  onPress={this.onPress7}></Button>
+                </View>
             </View>
         );
     }
@@ -70,6 +77,7 @@ class App extends React.Component {
                     <Stack.Screen name="GestureHandlers" component={GestureHandlers} />
                     <Stack.Screen name="Buttons" component={Buttons} />
                     <Stack.Screen name="Touchables" component={Touchables} />
+                    <Stack.Screen name="滴滴出行" component={DDGestureDemo} />
                 </Stack.Navigator>
             </NavigationContainer>
         );

--- a/react-native-gesture-handler/DDGestureDemo.tsx
+++ b/react-native-gesture-handler/DDGestureDemo.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Animated, StyleSheet, Button, View, Text, Platform } from 'react-native'
+import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
+
+
+const DDGestureTest3: React.FC = () => {
+const [resultText, setResultText] = useState('[result')
+
+const [logs, setLogs] = useState('')
+const [mockblockLeft, setMockblockLeft] = useState(50)
+const [mockblockTop, setMockblockTop] = useState(50)
+const [mockblockLeftShared, setMockblockLeftShared] = useState(50)
+const [mockblockTopShared, setMockblockTopShared] = useState(50)
+const runOnJS = true
+const [showNormal] = useState(false)
+
+const log = (...args: any[]) => {
+	setLogs(args.join(' '))
+}
+const gestures =  useMemo(() => {
+	const doubleTap = Gesture.Tap()
+		.runOnJS(runOnJS)
+		.numberOfTaps(2)
+		.onEnd(e => log('double tap', e.numberOfPointers));
+
+	const singleTap = Gesture.Tap()
+		.runOnJS(runOnJS)
+		.maxDistance(10)
+		.onEnd(e => log('single tap', e.numberOfPointers));
+
+	const longPressGesture = Gesture.LongPress()
+		.runOnJS(runOnJS)
+		.onEnd(e => log('long press'));
+
+	const panGesture = Gesture.Pan()
+		.runOnJS(runOnJS)
+		.maxPointers(1)
+		.onStart(e => log('pan start'))
+		.onUpdate(e => {
+			log('pan           pan update')
+			if (showNormal) {
+				setMockblockLeft(e.x)
+				setMockblockTop(e.y)
+			}
+			mockblockLeftShared.value = e.x
+			mockblockTopShared.value = e.y
+		})
+		.onEnd(e => log('pan end'));
+
+	const pinchGesture = Gesture.Pinch()
+		.runOnJS(runOnJS)
+		.onStart(e => log('pinch start'))
+		.onUpdate(e => log('pinch update'))
+		.onEnd(e => log('pinch end'));
+
+	const rotationGesture = Gesture.Rotation()
+		.runOnJS(runOnJS)
+		.onStart(e => log('rotation start'))
+		.onUpdate(e => log('rotation update'))
+		.onEnd(e => log('rotation end'));
+
+	const tapGestures = [
+		doubleTap,
+		singleTap,
+		longPressGesture,
+	]
+
+
+return Gesture.Race(
+			Gesture.Exclusive(
+				panGesture,
+				Gesture.Race(
+					pinchGesture, 
+					rotationGesture
+				),
+			),
+			Gesture.Exclusive(
+				...tapGestures
+			)
+		)
+}, [])
+
+	return (
+	<View style={{marginTop:80}}>
+		<Text style={{fontSize:18,fontWeight:500}}>Problem：The current demo reproduces the problem that pinching and rotating gestures are confused</Text>
+		<Text style={{fontSize:18,fontWeight:500,marginTop:20}}>Description：Please continuously operate any gesture in the rotation/pinching area in the red wire frame below, and observe whether the log on the screen corresponds to the gesture of the operation.</Text>
+		<GestureHandlerRootView>
+			<GestureDetector gesture={gestures}>
+				<View style={styles.container}>
+					<Text style={{fontSize:16,fontWeight:500}}>Logs: {logs}</Text>
+					
+				</View>
+			</GestureDetector>
+		</GestureHandlerRootView>
+	</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	container: {
+		width: 300,
+		height: 300,
+		borderColor: 'red',
+		borderWidth: 1,
+		marginTop: 20,
+		marginLeft:50,
+		position: 'relative'
+	},
+	mockblock: {
+		width: 100,
+		height: 100,
+		backgroundColor: 'red',
+		position: 'absolute'
+	},
+})
+
+export default DDGestureTest3


### PR DESCRIPTION
# Summary

- 新增pan和捏合手势的混合场景；
- 修复触摸点个数不正确的问题；
- 处理连续双击夹杂打击的问题。


## Test Plan

![1749462383907](https://github.com/user-attachments/assets/0760ab50-8754-41d0-b498-72815ac600f1)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
