### PR TITLE
test: 增加支持录制AAC容器格式的配置按钮

### DIFF
--- a/react-native-audio/AudioDemo.tsx
+++ b/react-native-audio/AudioDemo.tsx
@@ -109,7 +109,7 @@ export const AudioDemo = () => {
                 </View>
                 <View style={{ marginTop: 10 }}>
                     <Button
-                        title="prepare"
+                        title="preparem4a"
                         onPress={async () => {
                             // let file_name = autoGenAudioName();
                             let file_name = 'audio_demo';
@@ -121,6 +121,27 @@ export const AudioDemo = () => {
                                 AudioEncodingBitRate: Number(audioEncodingBitRate),
                                 AudioSource: 1,
                                 OutputFormat: 'm4a',
+                                IncludeBase64: includeBase64
+                            }
+                            await AudioRecorder.prepareRecordingAtPath(`${AudioUtils[fileFlag]}/${file_name}.m4a`, options);
+                            console.log(`AudioRecorder : ,${AudioUtils[fileFlag]}/${file_name}.m4a`);
+                        }}
+                    />
+                </View>
+                <View style={{ marginTop: 10 }}>
+                    <Button
+                        title="prepareAAC"
+                        onPress={async () => {
+                            // let file_name = autoGenAudioName();
+                            let file_name = 'audio_demo';
+                            setTempFileName(file_name);
+                            const options = {
+                                SampleRate: Number(audioSampleRate),
+                                Channels: Number(audioChannels),
+                                AudioEncoding: 'aac',
+                                AudioEncodingBitRate: Number(audioEncodingBitRate),
+                                AudioSource: 1,
+                                OutputFormat: 'aac',
                                 IncludeBase64: includeBase64
                             }
                             await AudioRecorder.prepareRecordingAtPath(`${AudioUtils[fileFlag]}/${file_name}.m4a`, options);


### PR DESCRIPTION
# Summary
1: test: 增加支持录制AAC容器格式的配置按钮

## Test Plan
<img width="371" height="712" alt="react-native-audio" src="https://github.com/user-attachments/assets/49f9cecb-6f1d-4f70-af97-cb4bd4c107cb" />


## Checklist
- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
