### PR TITLE
test: 新增flash-list测试用例以测试MasonryFlashList组件的onScroll事件处理功能

### DIFF
--- a/@shopify/flash-list/FlashListDemo5.tsx
+++ b/@shopify/flash-list/FlashListDemo5.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { MasonryFlashList, FlashList } from '@shopify/flash-list'
+import { Text, View, FlatList, ScrollView, Alert } from 'react-native'
+import { TestCase, Tester, TestSuite } from '@rnoh/testerino'
+
+const OnScrollDemo: React.FC = () => {
+    const [data, setData] = useState<number[]>([])
+    const [hasMore, setHasMore] = useState<boolean>(false)
+    const [toastMessage, setToastMessage] = useState<string>('')
+    const [showToast, setShowToast] = useState<boolean>(false)
+
+    useEffect(() => {
+        setTimeout(() => {
+            setData(Array.from(new Array(1000).fill(1)))
+            setHasMore(true)
+        }, 200)
+    }, [])
+
+    const showToastMessage = (message: string) => {
+        setToastMessage(message)
+        setShowToast(true)
+
+        setTimeout(() => {
+            setShowToast(false)
+        }, 500)
+    }
+
+    const renderItem = useCallback(() => (
+        <View style={{ height: 200, borderBottomWidth: 1, borderBottomColor: '#F00' }}>
+            <Text>{Math.random()}</Text>
+        </View>
+    ), [])
+
+    console.log('OnScrollDemo111  render', { hasMore, length: data.length })
+    const handleScroll = () => {
+        if (hasMore && data.length > 0) {
+            console.log('OnScrollDemo111  should loadmore', { hasMore, length: data.length })
+            showToastMessage(`OnScroll triggered - Should load more (hasMore: ${hasMore}, items: ${data.length})`)
+        } else {
+            console.log('OnScrollDemo111  error', { hasMore, length: data.length })
+            showToastMessage(`OnScroll Error - Error state (hasMore: ${hasMore}, items: ${data.length})`)
+        }
+    }
+
+    return (
+        <Tester>
+            <TestSuite name="MasonryFlashList OnScroll">
+                <TestCase itShould="handle onScroll event when scrolling through items">
+                    <View style={{ height: '80%', width: '100%', position: 'relative' }}>
+                        <MasonryFlashList
+                            onScroll={handleScroll}
+                            renderItem={renderItem}
+                            data={data}
+                        />
+                        {showToast && (
+                            <View
+                                style={{
+                                    position: 'absolute',
+                                    bottom: 20,
+                                    left: 20,
+                                    right: 20,
+                                    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                                    paddingHorizontal: 16,
+                                    paddingVertical: 12,
+                                    borderRadius: 8,
+                                    zIndex: 1000,
+                                }}
+                            >
+                                <Text style={{ color: 'white', textAlign: 'center', fontSize: 14 }}>
+                                    {toastMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
+                </TestCase>
+            </TestSuite>
+        </Tester>
+    )
+}
+export default OnScrollDemo


### PR DESCRIPTION
# Summary
- test: 新增flash-list测试用例以测试MasonryFlashList组件的onScroll事件处理功能

## Test Plan

![页面截图](https://github.com/user-attachments/assets/066c3196-7733-4f48-9c6d-5b9c940ddb68)

<img width="689" height="437" alt="image" src="https://github.com/user-attachments/assets/da21c652-a552-4379-be09-63a91001ef54" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)