### PR TITLE
test:新增@react-native-oh-tpl/pull_to_refresh的demo

### DIFF
--- a/pull_to_refresh/CustomPullToRefreshFooter.tsx
+++ b/pull_to_refresh/CustomPullToRefreshFooter.tsx
@@ -1,0 +1,59 @@
+import {
+    PullToRefreshFooter,
+    PullToRefreshFooterProps,
+    PullToRefreshStateChangedEvent,
+    PullToRefreshOffsetChangedEvent,
+    PullToRefreshStateIdle,
+    PullToRefreshStateRefreshing,
+  } from '@sdcx/pull-to-refresh'
+  import React, {useCallback, useRef, useState} from 'react';
+  import {StyleSheet,Image ,Text,Animated} from 'react-native';
+
+  export function CustomPullToRefreshFooter(props: PullToRefreshFooterProps) {
+    const { onRefresh, refreshing, noMoreData } = props
+  
+    const [text, setText] = useState('上拉加载更多')
+  
+    const onStateChanged = useCallback((event: PullToRefreshStateChangedEvent) => {
+      const state = event.nativeEvent.state
+      console.log('refresh footer state', event.nativeEvent.state)
+      if (state === PullToRefreshStateIdle) {
+        setText('上拉加载更多')
+      } else if (state === PullToRefreshStateRefreshing) {
+        setText('正在加载更多...')
+      } else {
+        setText('松开加载更多')
+      }
+    }, [])
+  
+    const onOffsetChanged = useCallback((event: PullToRefreshOffsetChangedEvent) => {
+      console.log('refresh footer offset11', event.nativeEvent.offset)
+    }, [])
+  
+    return (
+      <PullToRefreshFooter
+        style={styles.container}
+        manual={true /* 设置模式为手动 */}
+        onOffsetChanged={onOffsetChanged}
+        onStateChanged={onStateChanged}
+        onRefresh={onRefresh}
+        refreshing={refreshing}
+        noMoreData={noMoreData}>
+        <Animated.View style={{ height: 50, width: '100%', justifyContent: "center", alignItems: 'center' }}>
+          <Text style={styles.text}>{noMoreData ? '没有更多数据了' : text}</Text>
+       </Animated.View>
+      
+      </PullToRefreshFooter>
+    )
+  }
+  const styles = StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      width:'100%',
+      height: 0,
+    },
+    text: {
+      color:'red'
+    },
+  });

--- a/pull_to_refresh/PullRefreshFlatList/FlatListPage.tsx
+++ b/pull_to_refresh/PullRefreshFlatList/FlatListPage.tsx
@@ -1,0 +1,64 @@
+import React, {useState} from 'react';
+import {FlatList, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
+
+const FLATLIST_DATA = Array(40)
+  .fill(Math.random() + '')
+  .map((item, index) => ({
+    id: item + index,
+    title: `index: ${index} `,
+  }));
+
+const generateFlatlistItem = (index: number, extra: string) => ({
+  id: Math.random() + '' + index,
+  title: `${extra} index ${index}`,
+});
+
+export function useDemoFlatlistData() {
+  const [flatlistData, setFlatlistData] = useState(FLATLIST_DATA);
+  return {
+    flatlistData,
+    addFlatlistRefreshItem: () =>
+      setFlatlistData(data => [generateFlatlistItem(data.length, 'refresh'), ...data]),
+    addFlatlistLoadMoreItem: () =>
+      setFlatlistData([...flatlistData, generateFlatlistItem(flatlistData.length, 'load more')]),
+  };
+}
+
+export function FlatListPage({data = FLATLIST_DATA}: {data?: {id: string; title: string}[]}) {
+  const renderItem = ({item}: {item: {title: string}}) => <Item title={item.title} />;
+
+  return (
+    <FlatList
+      onLayout={e => console.log('flatlist', e.nativeEvent.layout.height)}
+      contentContainerStyle={{flexGrow: 1}}
+      data={data}
+      renderItem={renderItem}
+      keyExtractor={item => item.id}
+      nestedScrollEnabled
+    />
+  );
+}
+const Item = ({title}: {title: string}) => {
+  const [clickCount, setClickCount] = useState(0);
+  return (
+    <TouchableHighlight onPress={() => setClickCount(v => v + 1)} underlayColor="#DDDDDD">
+      <View style={styles.item}>
+        <Text style={styles.title}>
+          {title} {clickCount}
+        </Text>
+      </View>
+    </TouchableHighlight>
+  );
+};
+
+const styles = StyleSheet.create({
+  item: {
+    backgroundColor: '#f9c2ff',
+    padding: 20,
+    marginVertical: 8,
+    marginHorizontal: 16,
+  },
+  title: {
+    fontSize: 32,
+  },
+});

--- a/pull_to_refresh/PullRefreshFlatList/index.tsx
+++ b/pull_to_refresh/PullRefreshFlatList/index.tsx
@@ -1,0 +1,64 @@
+// import {withNavigationItem} from 'hybrid-navigation';
+import React, {useRef, useState} from 'react';
+import {PullToRefresh} from '@sdcx/pull-to-refresh';
+import {FlatListPage, useDemoFlatlistData} from './FlatListPage';
+import {SpinnerPullToRefreshHeader} from '../SpinnerPullToRefreshHeader';
+import { Tester, Filter, TestCase, TestSuite } from '@rnoh/testerino';
+import {CustomPullToRefreshFooter} from '../CustomPullToRefreshFooter'
+function PullRefreshFlatList() {
+  const [refreshing, setRefreshing] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(true);
+  const [noMoreData, setNoMoreData] = useState(false);
+  const {flatlistData, addFlatlistRefreshItem, addFlatlistLoadMoreItem} = useDemoFlatlistData();
+  const pendingAction = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingAction = () => {
+    if (pendingAction.current) {
+      clearTimeout(pendingAction.current);
+    }
+  };
+
+  const beginRefresh = async () => {
+    setRefreshing(true);
+    pendingAction.current = setTimeout(() => {
+      addFlatlistRefreshItem();
+      endRefresh();
+    }, 2000);
+  };
+
+  const endRefresh = () => {
+    clearPendingAction();
+    setRefreshing(false);
+    setNoMoreData(false);
+  };
+
+  const loadMore = () => {
+    setLoadingMore(true);
+    pendingAction.current = setTimeout(() => {
+      addFlatlistLoadMoreItem();
+      endLoadMore();
+    }, 3500);
+  };
+
+  const endLoadMore = () => {
+    clearPendingAction();
+    setLoadingMore(false);
+    setNoMoreData(true);
+  };
+
+  return (
+    <Tester style={{ flex: 1, marginTop: 30 }}>
+        <PullToRefresh
+          style={{height: '100%'}}
+          header={<SpinnerPullToRefreshHeader refreshing={refreshing} onRefresh={
+            beginRefresh
+          } />}
+          footer={<CustomPullToRefreshFooter refreshing={loadingMore} onRefresh={loadMore} />}
+          >
+          <FlatListPage data={flatlistData} />
+        </PullToRefresh>
+    </Tester>
+  );
+}
+
+export default PullRefreshFlatList;

--- a/pull_to_refresh/SpinnerPullToRefreshHeader.tsx
+++ b/pull_to_refresh/SpinnerPullToRefreshHeader.tsx
@@ -1,0 +1,54 @@
+import React, {useCallback, useRef, useState} from 'react';
+import {StyleSheet,Image ,Text,Animated} from 'react-native';
+import {
+  PullToRefreshHeader,
+  PullToRefreshHeaderProps,
+  PullToRefreshStateChangedEvent,
+  PullToRefreshState,
+  PullToRefreshStateIdle,
+  PullToRefreshStateRefreshing,
+  PullToRefreshOffsetChangedEvent
+} from '@sdcx/pull-to-refresh';
+
+function SpinnerPullToRefreshHeader(props: PullToRefreshHeaderProps) {
+  const stateRef = useRef<PullToRefreshState>(PullToRefreshStateIdle);
+  const [animating, setAnimating] = useState(false);
+
+  const onStateChanged = useCallback((event: PullToRefreshStateChangedEvent) => {
+    const state = event.nativeEvent.state;
+    console.log('refresh header onStateChanged state', state);
+    stateRef.current = state;
+    if (state === PullToRefreshStateIdle) {
+      setAnimating(false);
+    } else if (state === PullToRefreshStateRefreshing) {
+      setAnimating(true);
+    } else {
+    //   HapticFeedback.trigger('effectClick');
+    }
+  }, []);
+  const onOffsetChanged = useCallback((event: PullToRefreshOffsetChangedEvent) => {
+    console.log('refresh header offset', event.nativeEvent.offset);
+  }, []);
+
+  return (
+    <PullToRefreshHeader style={styles.header} {...props} onStateChanged={onStateChanged} onOffsetChanged={onOffsetChanged}>
+      <Animated.View style={{ height: 50, width: '100%', justifyContent: "center", alignItems: 'center' }}>
+          <Text style={{color:"red"}}>刷新头部（包裹的PullToRefreshHeader高度需要设置0）</Text>
+       </Animated.View>
+    </PullToRefreshHeader>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 0,
+    width:'100%'
+  },
+  spinner: {
+    transform: [{scale: 0.75}],
+  },
+});
+
+export {SpinnerPullToRefreshHeader};


### PR DESCRIPTION
# Summary

- test:新增@react-native-oh-tpl/pull_to_refresh的demo
- closed: #1692 


## Test Plan

![screenshot_20250924_182259](https://github.com/user-attachments/assets/6c7937e9-4398-46c1-b560-df11258eb96e)
![screenshot_20250924_182450](https://github.com/user-attachments/assets/f81283ab-1324-4404-bdbd-e82004e70bf1)

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例）
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码
